### PR TITLE
Rna transcription fix

### DIFF
--- a/exercises/rna-transcription/Sources/RnaTranscriptionExample.swift
+++ b/exercises/rna-transcription/Sources/RnaTranscriptionExample.swift
@@ -1,6 +1,11 @@
-struct Nucleotide {
+enum TranscriptionError: Error {
+    case InvalidNucleotide
+}
 
-    var complementOfDNA: String? { return transcribe(dnaToRna) }
+struct Nucleotide {
+    func complementOfDNA() throws -> String {
+        return try transcribe(dnaToRna)
+    }
 
     private let value: String
 
@@ -10,11 +15,11 @@ struct Nucleotide {
 
     private let dnaToRna: [Character:String] = [ "G": "C", "C": "G", "T": "A", "A": "U" ]
 
-    private func transcribe(_ dict: [Character : String]) -> String? {
+    private func transcribe(_ dict: [Character : String]) throws -> String {
         var tempText = ""
         for each in self.value.characters {
             if (dict[each] == nil) {
-                return nil
+                throw TranscriptionError.InvalidNucleotide
             }
             tempText += dict[each] ?? ""
         }

--- a/exercises/rna-transcription/Sources/RnaTranscriptionExample.swift
+++ b/exercises/rna-transcription/Sources/RnaTranscriptionExample.swift
@@ -1,6 +1,6 @@
 struct Nucleotide {
 
-    var complementOfDNA: String { return transcribe(dnaToRna) }
+    var complementOfDNA: String? { return transcribe(dnaToRna) }
 
     private let value: String
 
@@ -10,9 +10,12 @@ struct Nucleotide {
 
     private let dnaToRna: [Character:String] = [ "G": "C", "C": "G", "T": "A", "A": "U" ]
 
-    private func transcribe(_ dict: [Character : String]) -> String {
+    private func transcribe(_ dict: [Character : String]) -> String? {
         var tempText = ""
         for each in self.value.characters {
+            if (dict[each] == nil) {
+                return nil
+            }
             tempText += dict[each] ?? ""
         }
         return tempText

--- a/exercises/rna-transcription/Sources/RnaTranscriptionExample.swift
+++ b/exercises/rna-transcription/Sources/RnaTranscriptionExample.swift
@@ -18,7 +18,7 @@ struct Nucleotide {
     private func transcribe(_ dict: [Character : String]) throws -> String {
         var tempText = ""
         for each in self.value.characters {
-            if (dict[each] == nil) {
+            if dict[each] == nil {
                 throw TranscriptionError.InvalidNucleotide
             }
             tempText += dict[each] ?? ""

--- a/exercises/rna-transcription/Tests/RnaTranscriptionTests/RnaTranscriptionTests.swift
+++ b/exercises/rna-transcription/Tests/RnaTranscriptionTests/RnaTranscriptionTests.swift
@@ -23,19 +23,21 @@ class RnaTranscriptionTests: XCTestCase {
     }
     
     func testInvalidRnaComplementOfUracil() {
-        XCTAssertThrowsError(try Nucleotide("U").complementOfDNA())
-        
-//        XCTAssertThrowsError(try Nucleotide("U").complementOfDNA() { (error) -> Void in
-//                XCTAssertEqual(error as? TranscriptionError, TranscriptionError.InvalidNucleotide)
-//            })
+        XCTAssertThrowsError(try Nucleotide("U").complementOfDNA(), "This didn't work") { (error) in
+            XCTAssertEqual(error as? RnaTranscription.TranscriptionError, RnaTranscription.TranscriptionError.InvalidNucleotide)
+        }
     }
     
     func testInvalidRnaComplementOfXXX() {
-        XCTAssertThrowsError(try Nucleotide("XXX").complementOfDNA())
+        XCTAssertThrowsError(try Nucleotide("XXX").complementOfDNA(), "This didn't work") { (error) in
+            XCTAssertEqual(error as? RnaTranscription.TranscriptionError, RnaTranscription.TranscriptionError.InvalidNucleotide)
+        }
     }
     
     func testInvalidRnaComplementOfACGTXXXCTTAA() {
-        XCTAssertThrowsError(try Nucleotide("ACGTXXXCTTAA").complementOfDNA())
+        XCTAssertThrowsError(try Nucleotide("ACGTXXXCTTAA").complementOfDNA(), "This didn't work") { (error) in
+            XCTAssertEqual(error as? RnaTranscription.TranscriptionError, RnaTranscription.TranscriptionError.InvalidNucleotide)
+        }
     }
     
     static var allTests: [(String, (RnaTranscriptionTests) -> () throws -> Void)] {

--- a/exercises/rna-transcription/Tests/RnaTranscriptionTests/RnaTranscriptionTests.swift
+++ b/exercises/rna-transcription/Tests/RnaTranscriptionTests/RnaTranscriptionTests.swift
@@ -23,21 +23,30 @@ class RnaTranscriptionTests: XCTestCase {
     }
     
     func testInvalidRnaComplementOfUracil() {
-        XCTAssertThrowsError(try Nucleotide("U").complementOfDNA(), "This didn't work") { (error) in
-            XCTAssertEqual(error as? RnaTranscription.TranscriptionError, RnaTranscription.TranscriptionError.InvalidNucleotide)
-        }
+        XCTAssertThrowsError(try Nucleotide("U").complementOfDNA())
+        
+        // Uncomment to see more specific error handling
+//        XCTAssertThrowsError(try Nucleotide("U").complementOfDNA(), "This didn't work") { (error) in
+//            XCTAssertEqual(error as? RnaTranscription.TranscriptionError, RnaTranscription.TranscriptionError.InvalidNucleotide)
+//        }
     }
     
     func testInvalidRnaComplementOfXXX() {
-        XCTAssertThrowsError(try Nucleotide("XXX").complementOfDNA(), "This didn't work") { (error) in
-            XCTAssertEqual(error as? RnaTranscription.TranscriptionError, RnaTranscription.TranscriptionError.InvalidNucleotide)
-        }
+        XCTAssertThrowsError(try Nucleotide("XXX").complementOfDNA())
+        
+        // Uncomment to see more specific error handling
+//        XCTAssertThrowsError(try Nucleotide("XXX").complementOfDNA(), "This didn't work") { (error) in
+//            XCTAssertEqual(error as? RnaTranscription.TranscriptionError, RnaTranscription.TranscriptionError.InvalidNucleotide)
+//        }
     }
     
     func testInvalidRnaComplementOfACGTXXXCTTAA() {
-        XCTAssertThrowsError(try Nucleotide("ACGTXXXCTTAA").complementOfDNA(), "This didn't work") { (error) in
-            XCTAssertEqual(error as? RnaTranscription.TranscriptionError, RnaTranscription.TranscriptionError.InvalidNucleotide)
-        }
+        XCTAssertThrowsError(try Nucleotide("ACGTXXXCTTAA").complementOfDNA())
+        
+        // Uncomment to see more specific error handling
+//        XCTAssertThrowsError(try Nucleotide("ACGTXXXCTTAA").complementOfDNA(), "This didn't work") { (error) in
+//            XCTAssertEqual(error as? RnaTranscription.TranscriptionError, RnaTranscription.TranscriptionError.InvalidNucleotide)
+//        }
     }
     
     static var allTests: [(String, (RnaTranscriptionTests) -> () throws -> Void)] {

--- a/exercises/rna-transcription/Tests/RnaTranscriptionTests/RnaTranscriptionTests.swift
+++ b/exercises/rna-transcription/Tests/RnaTranscriptionTests/RnaTranscriptionTests.swift
@@ -21,7 +21,19 @@ class RnaTranscriptionTests: XCTestCase {
     func testRnaComplement() {
         XCTAssertEqual("UGCACCAGAAUU", Nucleotide("ACGTGGTCTTAA").complementOfDNA)
     }
-
+    
+    func testInvalidRnaComplementOfUracil() {
+        XCTAssertEqual(nil, Nucleotide("U").complementOfDNA)
+    }
+    
+    func testInvalidRnaComplementOfXXX() {
+        XCTAssertEqual(nil, Nucleotide("XXX").complementOfDNA)
+    }
+    
+    func testInvalidRnaComplementOfACGTXXXCTTAA() {
+        XCTAssertEqual(nil, Nucleotide("ACGTXXXCTTAA").complementOfDNA)
+    }
+    
     static var allTests: [(String, (RnaTranscriptionTests) -> () throws -> Void)] {
         return [
             ("testRnaComplementOfCytosineIsGuanine", testRnaComplementOfCytosineIsGuanine),
@@ -29,6 +41,9 @@ class RnaTranscriptionTests: XCTestCase {
             ("testRnaComplementOfThymineIsAdenine", testRnaComplementOfThymineIsAdenine),
             ("testRnaComplementOfAdenineIsUracil", testRnaComplementOfAdenineIsUracil),
             ("testRnaComplement", testRnaComplement),
+            ("testInvalidRnaComplementOfUracil", testInvalidRnaComplementOfUracil),
+            ("testInvalidRnaComplementOfXXX", testInvalidRnaComplementOfXXX),
+            ("testInvalidRnaComplementOfACGTXXXCTTAA", testInvalidRnaComplementOfACGTXXXCTTAA)
         ]
     }
 }

--- a/exercises/rna-transcription/Tests/RnaTranscriptionTests/RnaTranscriptionTests.swift
+++ b/exercises/rna-transcription/Tests/RnaTranscriptionTests/RnaTranscriptionTests.swift
@@ -3,35 +3,39 @@ import XCTest
 
 class RnaTranscriptionTests: XCTestCase {
     func testRnaComplementOfCytosineIsGuanine() {
-        XCTAssertEqual("G", Nucleotide("C").complementOfDNA)
+        XCTAssertEqual("G", try Nucleotide("C").complementOfDNA())
     }
 
     func testRnaComplementOfGuanineIsCytosine() {
-        XCTAssertEqual("C", Nucleotide("G").complementOfDNA)
+        XCTAssertEqual("C", try Nucleotide("G").complementOfDNA())
     }
 
     func testRnaComplementOfThymineIsAdenine() {
-        XCTAssertEqual("A", Nucleotide("T").complementOfDNA)
+        XCTAssertEqual("A", try Nucleotide("T").complementOfDNA())
     }
 
     func testRnaComplementOfAdenineIsUracil() {
-        XCTAssertEqual("U", Nucleotide("A").complementOfDNA)
+        XCTAssertEqual("U", try Nucleotide("A").complementOfDNA())
     }
 
     func testRnaComplement() {
-        XCTAssertEqual("UGCACCAGAAUU", Nucleotide("ACGTGGTCTTAA").complementOfDNA)
+        XCTAssertEqual("UGCACCAGAAUU", try Nucleotide("ACGTGGTCTTAA").complementOfDNA())
     }
     
     func testInvalidRnaComplementOfUracil() {
-        XCTAssertEqual(nil, Nucleotide("U").complementOfDNA)
+        XCTAssertThrowsError(try Nucleotide("XXX").complementOfDNA())
+        
+//        XCTAssertThrowsError(try Nucleotide("U").complementOfDNA() { (error) -> Void in
+//                XCTAssertEqual(error as? TranscriptionError, TranscriptionError.InvalidNucleotide)
+//            })
     }
     
     func testInvalidRnaComplementOfXXX() {
-        XCTAssertEqual(nil, Nucleotide("XXX").complementOfDNA)
+        XCTAssertThrowsError(try Nucleotide("XXX").complementOfDNA())
     }
     
     func testInvalidRnaComplementOfACGTXXXCTTAA() {
-        XCTAssertEqual(nil, Nucleotide("ACGTXXXCTTAA").complementOfDNA)
+        XCTAssertThrowsError(try Nucleotide("ACGTXXXCTTAA").complementOfDNA())
     }
     
     static var allTests: [(String, (RnaTranscriptionTests) -> () throws -> Void)] {

--- a/exercises/rna-transcription/Tests/RnaTranscriptionTests/RnaTranscriptionTests.swift
+++ b/exercises/rna-transcription/Tests/RnaTranscriptionTests/RnaTranscriptionTests.swift
@@ -21,34 +21,34 @@ class RnaTranscriptionTests: XCTestCase {
     func testRnaComplement() {
         XCTAssertEqual("UGCACCAGAAUU", try Nucleotide("ACGTGGTCTTAA").complementOfDNA())
     }
-    
+
     func testInvalidRnaComplementOfUracil() {
         XCTAssertThrowsError(try Nucleotide("U").complementOfDNA())
-        
+
         // Uncomment to see more specific error handling
 //        XCTAssertThrowsError(try Nucleotide("U").complementOfDNA(), "This didn't work") { (error) in
 //            XCTAssertEqual(error as? RnaTranscription.TranscriptionError, RnaTranscription.TranscriptionError.InvalidNucleotide)
 //        }
     }
-    
+
     func testInvalidRnaComplementOfXXX() {
         XCTAssertThrowsError(try Nucleotide("XXX").complementOfDNA())
-        
+
         // Uncomment to see more specific error handling
 //        XCTAssertThrowsError(try Nucleotide("XXX").complementOfDNA(), "This didn't work") { (error) in
 //            XCTAssertEqual(error as? RnaTranscription.TranscriptionError, RnaTranscription.TranscriptionError.InvalidNucleotide)
 //        }
     }
-    
+
     func testInvalidRnaComplementOfACGTXXXCTTAA() {
         XCTAssertThrowsError(try Nucleotide("ACGTXXXCTTAA").complementOfDNA())
-        
+
         // Uncomment to see more specific error handling
 //        XCTAssertThrowsError(try Nucleotide("ACGTXXXCTTAA").complementOfDNA(), "This didn't work") { (error) in
 //            XCTAssertEqual(error as? RnaTranscription.TranscriptionError, RnaTranscription.TranscriptionError.InvalidNucleotide)
 //        }
     }
-    
+
     static var allTests: [(String, (RnaTranscriptionTests) -> () throws -> Void)] {
         return [
             ("testRnaComplementOfCytosineIsGuanine", testRnaComplementOfCytosineIsGuanine),

--- a/exercises/rna-transcription/Tests/RnaTranscriptionTests/RnaTranscriptionTests.swift
+++ b/exercises/rna-transcription/Tests/RnaTranscriptionTests/RnaTranscriptionTests.swift
@@ -23,7 +23,7 @@ class RnaTranscriptionTests: XCTestCase {
     }
     
     func testInvalidRnaComplementOfUracil() {
-        XCTAssertThrowsError(try Nucleotide("XXX").complementOfDNA())
+        XCTAssertThrowsError(try Nucleotide("U").complementOfDNA())
         
 //        XCTAssertThrowsError(try Nucleotide("U").complementOfDNA() { (error) -> Void in
 //                XCTAssertEqual(error as? TranscriptionError, TranscriptionError.InvalidNucleotide)


### PR DESCRIPTION
The failure cases defined in `canonical-data.json` were not included in the original test code.

As a result, the one complex error case failed ("ACGTXXXCTTAA") when the original code returned a truncated version of the transcription, ignoring the "XXX" middle.

I've added the tests and fixed the code. It now returns `nil` as per the spec.