### PR TITLE
Call configlet subcommand on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,14 @@ matrix:
       osx_image: xcode8.3
     - script:
         - bin/fetch-configlet
-        - bin/configlet .
+        - bin/configlet lint .
         - docker run -v `pwd`:/swift norionomura/sourcekit:302 bash -c "cd /swift && ./xswift-test-spm"
       env: JOB=Linux302
       sudo: required
       services: docker
     - script:
         - bin/fetch-configlet
-        - bin/configlet .
+        - bin/configlet lint .
         - docker run -v `pwd`:/swift norionomura/sourcekit:31 bash -c "cd /swift && ./xswift-test-spm"
       env: JOB=Linux310
       sudo: required


### PR DESCRIPTION
This changes configlet to pass a subcommand.

For now, we've released a version of configlet which handles both the old command:

    configlet path/to/track

as well as the new command:

    configlet lint path/to/track

This will let us update all the travis files to include the subcommand before we
release the version of configlet that requires the subcommand.


https://github.com/exercism/configlet/pull/23