### PR TITLE
Add test for other allergies

### DIFF
--- a/exercises/allergies/Tests/AllergiesTests/AllergiesTests.swift
+++ b/exercises/allergies/Tests/AllergiesTests/AllergiesTests.swift
@@ -19,13 +19,18 @@ class AllergiesTests: XCTestCase {
         XCTAssertTrue(allergies.hasAllergy(.eggs))
         XCTAssertTrue(allergies.hasAllergy(.cats))
         XCTAssertFalse(allergies.hasAllergy(.chocolate))
-
     }
 
     func testNone() {
         let allergies = Allergies(0)
 
         XCTAssertFalse(allergies.hasAllergy(.pollen))
+    }
+
+    func testOtherAllergies() {
+        let allergies = Allergies(257)
+
+        XCTAssertTrue(allergies.hasAllergy(.eggs))
     }
 
     func testAll() {
@@ -49,6 +54,7 @@ class AllergiesTests: XCTestCase {
             ("testBob", testBob),
             ("testEggsNcats", testEggsNcats),
             ("testNone", testNone),
+            ("testOtherAllergies", testOtherAllergies),
             ("testAll", testAll),
         ]
     }


### PR DESCRIPTION
This PR updates the [Allergies](http://exercism.io/exercises/swift/allergies/readme) exercise and adds a new unit test. This test covers one of the stated criteria: 

`Note: a given score may include allergens not listed above (i.e. allergens that score 256, 512, 1024, etc.). Your program should ignore those components of the score. For example, if the allergy score is 257, your program should only report the eggs (1) allergy.`

The test just covers the case of a score of 257.