### PR TITLE
Rewrote tests to follow canonical data; reworked example to pass tests (fixes #232)

### DIFF
--- a/exercises/luhn/Sources/LuhnExample.swift
+++ b/exercises/luhn/Sources/LuhnExample.swift
@@ -3,32 +3,25 @@ import Foundation
 struct Luhn {
 
     var number: Int64 = 0
-    var addends: [Int] { return addendsFunc(number) }
+    var numberString: String = ""
+    var addends: [Int] { return addendsFunc(numberString) }
     var checksum: Int { return addends.reduce(0, +) }
-    var isValid: Bool { return checksum % 10 == 0 }
+    var isValid: Bool = false
 
-    init(_ num: Int64) {
-        self.number = num
-    }
-
-    static func create (_ num: Int64) -> Double {
-
-        func createCheckDigit(_ value: Int) -> Int {
-            let nearestTen = Int(ceil((Double(value) / 10.00)) * 10)
-            return nearestTen - value
+    init(_ num: String ) {
+        self.numberString = num.replacingOccurrences(of: " ", with: "")
+        let num = Int64(numberString)
+        if self.numberString.utf16.count <= 1 {
+            self.isValid = false
+        } else if num == nil {
+            isValid = false
+        } else {
+            self.number = num!
+            isValid = checksum % 10 == 0
         }
-
-        let zeroCheckDigitNumber = num * 10
-        let luhn = Luhn(zeroCheckDigitNumber)
-
-        if luhn.isValid {
-            return Double(zeroCheckDigitNumber)}
-
-        return Double((zeroCheckDigitNumber) + Int64(createCheckDigit(luhn.checksum)))
-
     }
 
-    func addendsFunc(_ num: Int64) -> [Int] {
+    func addendsFunc(_ num: String) -> [Int] {
         func oddIndexInt64Minus9( _ input: [Int]) -> [Int] {
             var input = input
             input = Array(input.reversed())
@@ -37,7 +30,7 @@ struct Luhn {
                 var tempEach: Int = each
                 if (inx+1) % 2 == 0 {
                     tempEach *= 2
-                    if tempEach > 10 {
+                    if tempEach >= 10 {
                         tempEach -= 9
                     }
                     tempArray.insert(tempEach, at: 0)
@@ -52,9 +45,7 @@ struct Luhn {
             return tempInt
         }
 
-        let tempString = "\(num)"
-
-        return oddIndexInt64Minus9(Array(tempString.characters).map { char2Int($0) })
+        return oddIndexInt64Minus9(Array(num.characters).map { char2Int($0) })
     }
 
 }

--- a/exercises/luhn/Tests/LinuxMain.swift
+++ b/exercises/luhn/Tests/LinuxMain.swift
@@ -2,5 +2,5 @@ import XCTest
 @testable import LuhnTests
 
 XCTMain([
-    testCase(LuhnTests.allTests),
+    testCase(LuhnTests.allTests)
     ])

--- a/exercises/luhn/Tests/LuhnTests/LuhnTests.swift
+++ b/exercises/luhn/Tests/LuhnTests/LuhnTests.swift
@@ -3,62 +3,86 @@ import XCTest
 
 class LuhnTests: XCTestCase {
 
-    func testAddends() {
-        let luhn = Luhn(12_121)
-        XCTAssertEqual([1, 4, 1, 4, 1], luhn.addends)
-    }
-
-    func testTooLargeAddend() {
-        let luhn = Luhn(8631)
-        XCTAssertEqual([7, 6, 6, 1], luhn.addends)
-    }
-
-    func testChecksum() {
-        let luhn = Luhn(4913)
-        XCTAssertEqual(22, luhn.checksum)
-    }
-
-    func testChecksumAgain() {
-        let luhn = Luhn(201_773)
-        XCTAssertEqual(21, luhn.checksum)
-    }
-
-    func testInvalidNumber() {
-        let luhn = Luhn(738)
+    func testSingleDigitInvalid() {
+        let luhn = Luhn("1")
         XCTAssertEqual (false, luhn.isValid)
     }
 
-    func testValidNumber() {
-        let luhn = Luhn(8_739_567)
+    func testSingleZeroInvalid() {
+        let luhn = Luhn("0")
+        XCTAssertEqual (false, luhn.isValid)
+    }
+
+    func testSimpleReversableValid() {
+        let luhn = Luhn("059")
         XCTAssertEqual (true, luhn.isValid)
     }
 
-    func testCreateValidNumber() {
-        let number = Luhn.create(123)
-        XCTAssertEqual(1230, number)
+    func testSimpleIrreversableValid() {
+        let luhn = Luhn("59")
+        XCTAssertEqual (true, luhn.isValid)
     }
 
-    func testCreateOtherValidNumber() {
-        let number = Luhn.create(873_956)
-        XCTAssertEqual(8_739_567, number)
+    func testCanadianValid() {
+        let luhn = Luhn("055 444 285")
+        XCTAssertEqual (true, luhn.isValid)
     }
 
-    func testCreateYetAnotherValidNumber() {
-        let number = Luhn.create(837_263_756)
-        XCTAssertEqual(8_372_637_564, number)
+    func testCanadianInvalid() {
+        let luhn = Luhn("055 444 286")
+        XCTAssertEqual (false, luhn.isValid)
+    }
+
+    func testCreditCardInvalid() {
+        let luhn = Luhn("8273 1232 7352 0569")
+        XCTAssertEqual (false, luhn.isValid)
+    }
+
+    func testNonDigitInvalid() {
+        let luhn = Luhn("055a 444 285")
+        XCTAssertEqual (false, luhn.isValid)
+    }
+
+    func testPunctuationInvalid() {
+        let luhn = Luhn("055-444-285")
+        XCTAssertEqual (false, luhn.isValid)
+    }
+
+    func testSymbolsInvalid() {
+        let luhn = Luhn("055£ 444$ 285")
+        XCTAssertEqual (false, luhn.isValid)
+    }
+
+    func testZeroWithSpaceInvalid() {
+        let luhn = Luhn(" 0")
+        XCTAssertEqual (false, luhn.isValid)
+    }
+
+    func testMultipleZeroesValid() {
+        let luhn = Luhn("0000 0")
+        XCTAssertEqual (true, luhn.isValid)
+    }
+
+    func testInputNineOutputNine() {
+        let luhn = Luhn("091")
+        XCTAssertEqual (true, luhn.isValid)
     }
 
     static var allTests: [(String, (LuhnTests) -> () throws -> Void)] {
         return [
-            ("testAddends", testAddends),
-            ("testTooLargeAddend", testTooLargeAddend),
-            ("testChecksum", testChecksum),
-            ("testChecksumAgain", testChecksumAgain),
-            ("testInvalidNumber", testInvalidNumber),
-            ("testValidNumber", testValidNumber),
-            ("testCreateValidNumber", testCreateValidNumber),
-            ("testCreateOtherValidNumber", testCreateOtherValidNumber),
-            ("testCreateYetAnotherValidNumber", testCreateYetAnotherValidNumber),
+            ("testSingleDigitInvalid", testSingleDigitInvalid),
+            ("testSingleZeroInvalid", testSingleZeroInvalid),
+            ("testSimpleReversableValid", testSimpleReversableValid),
+            ("testSimpleIrreversableValid", testSimpleIrreversableValid),
+            ("testCanadianValid", testCanadianValid),
+            ("testCanadianInvalid", testCanadianInvalid),
+            ("testCreditCardInvalid", testCreditCardInvalid),
+            ("testNonDigitInvalid", testNonDigitInvalid),
+            ("testPunctuationInvalid", testPunctuationInvalid),
+            ("testSymbolsInvalid", testSymbolsInvalid),
+            ("testZeroWithSpaceInvalid", testZeroWithSpaceInvalid),
+            ("testMultipleZeroesValid", testMultipleZeroesValid),
+            ("testInputNineOutputNine", testInputNineOutputNine)
         ]
     }
 }


### PR DESCRIPTION
The canonical data uses strings as input rather than ints, which required a partial rework of the example. Also, the example uses `>` where it should use `>=`, leading to a bug whenever a number contained the digit 5. I also removed an unused function from the example.