### PR TITLE
config.json: Fix invalid exercise UUID

### DIFF
--- a/config.json
+++ b/config.json
@@ -346,7 +346,7 @@
         "mathematics"
       ],
       "unlocked_by": null,
-      "uuid": "899bd49a-0970-9a80-5e6b-2adf5bfd0bf79f480ba"
+      "uuid": "6d70fd81-76a4-4e44-a64a-9a070e07e83d"
     },
     {
       "core": false,


### PR DESCRIPTION
The previous version of `configlet uuid` was known to generate invalid UUIDs. The latest release of Configlet [v3.6.1](https://github.com/exercism/configlet/releases) fixes that issue for newly added exercises, but existing exercise UUIDs need to be updated manually.

This change pertains to exercism/configlet#99