### PR TITLE
rotational-cipher: Generate missing exercise README

### DIFF
--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -1,0 +1,45 @@
+# Rotational Cipher
+
+Create an implementation of the rotational cipher, also sometimes called the Caesar cipher.
+
+The Caesar cipher is a simple shift cipher that relies on
+transposing all the letters in the alphabet using an integer key
+between `0` and `26`. Using a key of `0` or `26` will always yield
+the same output due to modular arithmetic. The letter is shifted
+for as many values as the value of the key.
+
+The general notation for rotational ciphers is `ROT + <key>`.
+The most commonly used rotational cipher is `ROT13`.
+
+A `ROT13` on the Latin alphabet would be as follows:
+
+```text
+Plain:  abcdefghijklmnopqrstuvwxyz
+Cipher: nopqrstuvwxyzabcdefghijklm
+```
+
+It is stronger than the Atbash cipher because it has 27 possible keys, and 25 usable keys.
+
+Ciphertext is written out in the same formatting as the input including spaces and punctuation.
+
+## Examples
+
+- ROT5  `omg` gives `trl`
+- ROT0  `c` gives `c`
+- ROT26 `Cool` gives `Cool`
+- ROT13 `The quick brown fox jumps over the lazy dog.` gives `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.`
+- ROT13 `Gur dhvpx oebja sbk whzcf bire gur ynml qbt.` gives `The quick brown fox jumps over the lazy dog.`
+
+## Setup
+
+Go through the project setup instructions for Xcode using Swift:
+
+http://exercism.io/languages/swift
+
+
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Caesar_cipher](https://en.wikipedia.org/wiki/Caesar_cipher)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.


### PR DESCRIPTION
In preparation for [v2](https://github.com/exercism/v2-feedback/blob/master/README.md) we're updating Configlet—our Exercism track linter—to require that we generate the exercise README. This is because in v2 we will not be generating READMEs on the fly, but deliver the README as defined in the directory for each implementation.

I'm going to go ahead and merge this as soon as the build passes, as this is janitorial work rather than a language-specific change.

See https://github.com/exercism/configlet/issues/116 for more details.