### PR TITLE
drop support for 3.1, add 4.1xdev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ matrix:
     - script:
         - bin/fetch-configlet
         - bin/configlet lint .
-        - docker run -v `pwd`:/swift norionomura/sourcekit:31 bash -c "cd /swift && ./xswift-test-spm"
-      env: JOB=Linux310
+        - docker run -v `pwd`:/swift norionomura/swift:swift-4.1-branch bash -c "cd /swift && ./xswift-test-spm"
+      env: JOB=Linux41x
       sudo: required
       services: docker
 


### PR DESCRIPTION
Stop tracking swift 3.1 and start tracking changes coming to swift 4.1x