### PR TITLE
Add the missing .gitignore in exercises

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -20,6 +20,18 @@ warn("Big PR") if git.lines_of_code > 500
 #ENSURE THERE IS A SUMMARY FOR A PR
 warn("Please provide a summary in the Pull Request description. See more info <a href=\"http\://tinyletter.com/exercism/letters/exercism-pull-requests\">here.</a>") if github.pr_body.length < 5
 
+# Ensure that .gitignore is included in new exercises
+(git.modified_files + git.added_files)
+  .map { |path|
+    match = %r{^(?<dir>exercises/[^/]+).*$}i.match(path) || {}
+    match[:dir]
+  }
+  .uniq
+  .reject(&:nil?)
+  .each { |dir|
+    warn "Missing `#{dir}/.gitignore`" unless File.exists? "#{dir}/.gitignore"
+  }
+
 # LINT Comments in for each Line
 jsonpath = "lintreport.json"
 contents = File.read jsonpath

--- a/exercises/collatz-conjecture/.gitignore
+++ b/exercises/collatz-conjecture/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/exercises/diamond/.gitignore
+++ b/exercises/diamond/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/exercises/isbn-verifier/.gitignore
+++ b/exercises/isbn-verifier/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/exercises/list-ops/.gitignore
+++ b/exercises/list-ops/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/exercises/protein-translation/.gitignore
+++ b/exercises/protein-translation/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/exercises/say/.gitignore
+++ b/exercises/say/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/exercises/scale-generator/.gitignore
+++ b/exercises/scale-generator/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj

--- a/exercises/two-fer/.gitignore
+++ b/exercises/two-fer/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+/.build
+/Packages
+/*.xcodeproj


### PR DESCRIPTION
Some of the exercises are missing `.gitignore` to exclude the swift package manager generated xcodeproj. This PR adds the missing files and updates Dangerfile to check future changes if needed.