### PR TITLE
config.json: Remove unlocked_by value from complex-numbers

### DIFF
--- a/config.json
+++ b/config.json
@@ -861,7 +861,7 @@
         "mathematics",
         "tuples"
       ],
-      "unlocked_by": "leap",
+      "unlocked_by": null,
       "uuid": "5a918ed8-e840-46b8-b824-291d872d2224"
     },
     {


### PR DESCRIPTION
## Problem
While linting with the latest release of [Configlet](https://github.com/exercism/configlet/releases/tag/v3.8.0) the exercise `complex-numbers` was found to contain an invalid unlocked_by configuration.

## What's changed
The master config file was updated in the following manner:

1. Removed the unlocked_by value of `"leap"` from `complex-numbers` seeing as there are currently no core exercises defined within the track.

## Testing Steps
1. Download the latest release of Configlet [here](https://github.com/exercism/configlet/releases/tag/v3.8.0)
1. Run `configlet lint <path-to-fsharp-track>`
1. Validate that there are no lint errors.