### PR TITLE
robot-name: test for upper-case letters

### DIFF
--- a/exercises/robot-name/Tests/RobotNameTests/RobotNameTests.swift
+++ b/exercises/robot-name/Tests/RobotNameTests/RobotNameTests.swift
@@ -14,7 +14,7 @@ import Foundation
 
 class RobotNameTests: XCTestCase {
     func robotNameIsCorrectlyFormatted(_ name: String) -> Bool {
-        let robotNameRegex = try? Regex(pattern: "\\A\\w{2}\\d{3}\\z", options: Regex.Options.caseInsensitive)
+        let robotNameRegex = try? Regex(pattern: "\\A[A-Z]{2}\\d{3}\\z")
         guard let matches = robotNameRegex?.matches(in: name, options: .withoutAnchoringBounds, range: NSRange(0..<name.utf16.count)) else { return false }
 
         return matches.count > 0


### PR DESCRIPTION
Name format is "two uppercase letters followed by three digits".

In this patch, regex `[A-Z]{2}` tests for two upper-case ASCII letters.

Original regex `\w{2}` expands to `[a-zA-Z0-9_]{2}` which is somewhat relaxed.

Alternative regex `\\p{Lu}{2}` could accept any Unicode upper-case letter.