### PR TITLE
scale-generator: fix enigmatic scale pattern

### DIFF
--- a/exercises/scale-generator/Tests/ScaleGeneratorTests/ScaleGeneratorTests.swift
+++ b/exercises/scale-generator/Tests/ScaleGeneratorTests/ScaleGeneratorTests.swift
@@ -89,7 +89,7 @@ class ScaleGeneratorTests: XCTestCase {
     }
 
     func testEnigmatic() {
-        let enigmatic = ScaleGenerator(tonic: "G", scaleName: "enigma", pattern: "mAMMMmM")
+        let enigmatic = ScaleGenerator(tonic: "G", scaleName: "enigma", pattern: "mAMMMmm")
         XCTAssertEqual(enigmatic.pitches(), ["G", "G#", "B", "C#", "D#", "F", "F#"])
     }
 


### PR DESCRIPTION
This fixes the scale to 12 half steps, as in [canonical-data](https://github.com/exercism/problem-specifications/blob/c85397312197906905c295ec7d026e53159d2fd4/exercises/scale-generator/canonical-data.json#L169-L177)
