### PR TITLE
Add 'math' topic to relevant exercises in track config

### DIFF
--- a/config.json
+++ b/config.json
@@ -53,7 +53,8 @@
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
-        "integers"
+        "integers",
+        "math"
       ]
     },
     {
@@ -75,6 +76,7 @@
       "difficulty": 1,
       "topics": [
         "lists",
+        "math",
         "transforming"
       ]
     },
@@ -286,7 +288,7 @@
       "difficulty": 3,
       "topics": [
         "filtering",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -308,7 +310,8 @@
       "difficulty": 3,
       "topics": [
         "discriminated_unions",
-        "integers"
+        "integers",
+        "math"
       ]
     },
     {
@@ -375,7 +378,7 @@
       "difficulty": 3,
       "topics": [
         "integers",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -572,6 +575,7 @@
       "difficulty": 4,
       "topics": [
         "integers",
+        "math",
         "transforming"
       ]
     },
@@ -583,6 +587,7 @@
       "difficulty": 4,
       "topics": [
         "integers",
+        "math",
         "strings",
         "transforming"
       ]
@@ -606,7 +611,7 @@
       "difficulty": 4,
       "topics": [
         "integers",
-        "mathematics",
+        "math",
         "records"
       ]
     },
@@ -629,7 +634,7 @@
       "difficulty": 4,
       "topics": [
         "lists",
-        "mathematics",
+        "math",
         "recursion"
       ]
     },
@@ -641,7 +646,7 @@
       "difficulty": 4,
       "topics": [
         "integers",
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -830,7 +835,7 @@
       "unlocked_by": null,
       "difficulty": 6,
       "topics": [
-        "mathematics"
+        "math"
       ]
     },
     {
@@ -841,6 +846,7 @@
       "difficulty": 6,
       "topics": [
         "algorithms",
+        "math",
         "strings",
         "tuples"
       ]
@@ -874,7 +880,7 @@
       "unlocked_by": null,
       "difficulty": 6,
       "topics": [
-        "mathematics",
+        "math",
         "tuples"
       ]
     },


### PR DESCRIPTION
The new site lets people filter optional exercises by topic, and this
makes it easy for people to skip past them.

This is important since the math-y exercises are not key to learning
the language, and a lot of people find them intimidating and demotivating.

This updates any 'mathematics' topics to be 'math' since it's shorter
and won't get cropped in the UI.

It also removes the math topics for any exercises that are not in the
canonical math-y list.


exercism/exercism.io#4110