### PR TITLE
difference-of-squares: renamed squareOfSums to squareOfSum

### DIFF
--- a/exercises/difference-of-squares/Sources/DifferenceOfSquaresExample.swift
+++ b/exercises/difference-of-squares/Sources/DifferenceOfSquaresExample.swift
@@ -8,7 +8,7 @@ struct Squares {
         }
     }
 
-    var squareOfSums: Int {
+    var squareOfSum: Int {
         let numbers = Array(1...self.max)
         let sum = numbers.reduce(0, + )
         return sum * sum
@@ -20,6 +20,6 @@ struct Squares {
     }
 
     var differenceOfSquares: Int {
-        return squareOfSums - sumOfSquares
+        return squareOfSum - sumOfSquares
     }
 }

--- a/exercises/difference-of-squares/Tests/DifferenceOfSquaresTests/DifferenceOfSquaresTests.swift
+++ b/exercises/difference-of-squares/Tests/DifferenceOfSquaresTests/DifferenceOfSquaresTests.swift
@@ -3,53 +3,53 @@ import XCTest
 
 class DifferenceOfSquaresTests: XCTestCase {
 
-    func testSquareOfSumsTo5() {
-        XCTAssertEqual(225, Squares(5).squareOfSums)
+    func testSquareOfSumTo5() {
+        XCTAssertEqual(225, Squares(5).squareOfSum)
     }
 
     func testSumOfSquaresTo5() {
         XCTAssertEqual(55, Squares(5).sumOfSquares)
     }
 
-    func testDifferenceOfSquaresOfSumsTo5() {
+    func testDifferenceOfSquaresOfSumTo5() {
         XCTAssertEqual(170, Squares(5).differenceOfSquares)
     }
 
-    func testSquareOfSumsTo10() {
-        XCTAssertEqual(3025, Squares(10).squareOfSums)
+    func testSquareOfSumTo10() {
+        XCTAssertEqual(3025, Squares(10).squareOfSum)
     }
 
     func testSumOfSquaresTo10() {
         XCTAssertEqual(385, Squares(10).sumOfSquares)
     }
 
-    func testDifferenceOfSquaresOfSumsTo10() {
+    func testDifferenceOfSquaresOfSumTo10() {
         XCTAssertEqual(2640, Squares(10).differenceOfSquares)
     }
 
-    func testSquareOfSumsTo100() {
-        XCTAssertEqual(25_502_500, Squares(100).squareOfSums)
+    func testSquareOfSumTo100() {
+        XCTAssertEqual(25_502_500, Squares(100).squareOfSum)
     }
 
     func testSumOfSquaresTo100() {
         XCTAssertEqual(338_350, Squares(100).sumOfSquares)
     }
 
-    func testDifferenceOfSquaresOfSumsTo100() {
+    func testDifferenceOfSquaresOfSumTo100() {
         XCTAssertEqual(25_164_150, Squares(100).differenceOfSquares)
     }
 
     static var allTests: [(String, (DifferenceOfSquaresTests) -> () throws -> Void)] {
         return [
-            ("testSquareOfSumsTo5", testSquareOfSumsTo5),
+            ("testSquareOfSumTo5", testSquareOfSumTo5),
             ("testSumOfSquaresTo5", testSumOfSquaresTo5),
-            ("testDifferenceOfSquaresOfSumsTo5", testDifferenceOfSquaresOfSumsTo5),
-            ("testSquareOfSumsTo10", testSquareOfSumsTo10),
+            ("testDifferenceOfSquaresOfSumTo5", testDifferenceOfSquaresOfSumTo5),
+            ("testSquareOfSumTo10", testSquareOfSumTo10),
             ("testSumOfSquaresTo10", testSumOfSquaresTo10),
-            ("testDifferenceOfSquaresOfSumsTo10", testDifferenceOfSquaresOfSumsTo10),
-            ("testSquareOfSumsTo100", testSquareOfSumsTo100),
+            ("testDifferenceOfSquaresOfSumTo10", testDifferenceOfSquaresOfSumTo10),
+            ("testSquareOfSumTo100", testSquareOfSumTo100),
             ("testSumOfSquaresTo100", testSumOfSquaresTo100),
-            ("testDifferenceOfSquaresOfSumsTo100", testDifferenceOfSquaresOfSumsTo100),
+            ("testDifferenceOfSquaresOfSumTo100", testDifferenceOfSquaresOfSumTo100),
         ]
     }
 }


### PR DESCRIPTION
In exercise "difference-of-squares", renamed `squareOfSums` to `squareOfSum`.