### PR TITLE
Fix warnings related to old String's character view property

### DIFF
--- a/exercises/accumulate/Tests/AccumulateTests/AccumulateTests.swift
+++ b/exercises/accumulate/Tests/AccumulateTests/AccumulateTests.swift
@@ -2,11 +2,11 @@ import XCTest
 @testable import Accumulate
 
 private extension String {
-    var length: Int { return self.characters.count }
+    var length: Int { return self.count }
 
     func reverse() -> String {
         var result: String = ""
-        for char in self.characters {
+        for char in self {
             result = "\(char)\(result)"
         }
         return result

--- a/exercises/acronym/Sources/AcronymExample.swift
+++ b/exercises/acronym/Sources/AcronymExample.swift
@@ -3,8 +3,8 @@ import Foundation
 private extension String {
 
     func substringWithRangeInt(_ intRange: CountableRange<Int>) -> String {
-        let start = self.characters.index(self.startIndex, offsetBy: intRange.lowerBound)
-        let end = self.characters.index(self.startIndex, offsetBy: intRange.upperBound)
+        let start = self.index(self.startIndex, offsetBy: intRange.lowerBound)
+        let end = self.index(self.startIndex, offsetBy: intRange.upperBound)
         return self.substring(with: start..<end)
     }
 
@@ -46,18 +46,18 @@ struct Acronym {
             var accumulate  = ""
             var lastIndexAdded = 0
 
-            for (index, each) in inString.characters.map({ String($0) }).enumerated() {
+            for (index, each) in inString.map({ String($0) }).enumerated() {
                 if splitCamelcaseAt(each, withString: &previousLetter) {
                     accumulate += inString.substringWithRangeInt(lastIndexAdded, end: index)+" " // inserts a space
                     lastIndexAdded = index
                 }
             }
-            let lastStringSection = inString.substringWithRangeInt(lastIndexAdded, end: inString.characters.count)
+            let lastStringSection = inString.substringWithRangeInt(lastIndexAdded, end: inString.count)
             return accumulate + lastStringSection
         }
 
         func splitAt(_ characterToCompare: Character, charToSplitAt: String = " ,-:") -> Bool {
-            for each in charToSplitAt.characters where each == characterToCompare {
+            for each in charToSplitAt where each == characterToCompare {
                 return true
             }
             return false
@@ -65,7 +65,7 @@ struct Acronym {
 
         func splitStringToArray(_ inString: String) -> [String] {
 
-            return inString.characters.split(whereSeparator: { splitAt($0) }).map { String($0) }
+            return inString.split(whereSeparator: { splitAt($0) }).map { String($0) }
         }
 
         return splitStringToArray(insertSpaceAtCamelcase(inString)).map({ $0.uppercased().substringWithRangeInt(0, end: 1) }).joined(separator: "")

--- a/exercises/anagram/Sources/AnagramExample.swift
+++ b/exercises/anagram/Sources/AnagramExample.swift
@@ -6,7 +6,7 @@ struct Anagram {
 
     func sortLetters(_ wordToSort: String) -> String {
         var characters: [String] = []
-        for char in wordToSort.characters {
+        for char in wordToSort {
             characters.append("\(char)")
         }
         characters = characters.sorted(by: < )

--- a/exercises/atbash-cipher/Sources/AtbashCipherExample.swift
+++ b/exercises/atbash-cipher/Sources/AtbashCipherExample.swift
@@ -4,7 +4,7 @@ struct AtbashCipher {
 
     private static func stripWhiteSpaceAndPunctuations(_ input: String) -> String {
         var returnString = ""
-        input.characters.forEach {
+        input.forEach {
             if !" ,.".contains(String($0)) {
                 returnString.append($0)
             }
@@ -20,7 +20,7 @@ struct AtbashCipher {
 
         var text2return = ""
 
-        for each in value.characters {
+        for each in value {
             text2return.append(cipherDictApply[each] ?? each )
         }
         return insertSpace5th(text2return)
@@ -29,7 +29,7 @@ struct AtbashCipher {
     static func insertSpace5th(_ value: String) -> String {
         var tempCounter = 0
         var tempString: String = ""
-        for each in value.characters {
+        for each in value {
             if tempCounter % 5 == 0 && tempCounter != 0 {
                 tempString += " \(each)"
             } else { tempString += "\(each)" }

--- a/exercises/binary/Sources/BinaryExample.swift
+++ b/exercises/binary/Sources/BinaryExample.swift
@@ -13,7 +13,7 @@ struct Binary {
     }
 
     private func bi2Uint(_ input: String) -> UInt? {
-        let orderedInput = Array(input.characters.reversed())
+        let orderedInput = Array(input.reversed())
         var tempUInt: UInt = 0
         for (inx, each) in orderedInput.enumerated() {
             if each == "1" {

--- a/exercises/bob/Sources/BobExample.swift
+++ b/exercises/bob/Sources/BobExample.swift
@@ -5,20 +5,20 @@ private extension String {
     func trimWhiteSpace() -> String {
         let removeSpaces = trimCharacters(" ", sourceText: self)
         if removeSpaces.hasSuffix("\n") {
-            return String(removeSpaces.characters.dropLast())
+            return String(removeSpaces.dropLast())
         }
         return  removeSpaces
     }
 
     func trimCharacters(_ charToTrim: Character, sourceText: String) -> String {
-        var editCharacterView = sourceText.characters
+        var editCharacterView = Array(sourceText)
         var editString = String(editCharacterView)
 
-        let trimFirst  = sourceText.characters.first == charToTrim
-        let trimLast   = sourceText.characters.last == charToTrim
+        let trimFirst  = sourceText.first == charToTrim
+        let trimLast   = sourceText.last == charToTrim
 
-        if trimFirst { editCharacterView  = editCharacterView.dropFirst() }
-        if trimLast { editCharacterView  = editCharacterView.dropLast() }
+        if trimFirst { editCharacterView  = Array(editCharacterView.dropFirst()) }
+        if trimLast { editCharacterView  = Array(editCharacterView.dropLast()) }
 
         if trimFirst || trimLast == true {
             editString = trimCharacters(charToTrim, sourceText: String(editCharacterView))
@@ -41,8 +41,8 @@ private extension String {
     private func containsLetters(_ input: String) -> Bool {
         let abc = "abcdefghijklmnopqrstuvwxyz"
         var contains = false
-        let inputStringCollection = input.characters.map({ String($0) })
-        let abcStringCollection = abc.characters.map({ String($0) })
+        let inputStringCollection = input.map({ String($0) })
+        let abcStringCollection = abc.map({ String($0) })
 
         for each in inputStringCollection {
             abcStringCollection.forEach({

--- a/exercises/bracket-push/Sources/BracketPushExample.swift
+++ b/exercises/bracket-push/Sources/BracketPushExample.swift
@@ -9,7 +9,7 @@ struct BracketPush {
     static func paired(text: String) -> Bool {
         var stack = [Character]()
 
-        for character in text.characters {
+        for character in text {
             if brackets.values.contains(character) {
                 stack.append(character)
             } else if brackets.keys.contains(character) {

--- a/exercises/crypto-square/Sources/CryptoSquareExample.swift
+++ b/exercises/crypto-square/Sources/CryptoSquareExample.swift
@@ -4,7 +4,7 @@ private extension String {
 
     func stripCharacters(_ charToRemove: String) -> String {
         var returnString = ""
-        self.characters.forEach {
+        self.forEach {
             if !charToRemove.contains(String($0)) {
                 returnString.append($0)
             }}
@@ -21,7 +21,7 @@ struct Crypto {
     func segmentSorter(_ value: String, spacing: Int) -> [String] {
         var tempCounter = 0
         var tempString: String = ""
-        for each in value.characters {
+        for each in value {
             if tempCounter % spacing == 0 && tempCounter != 0 {
                 tempString += " \(each)"
             } else { tempString += "\(each)" }
@@ -31,7 +31,7 @@ struct Crypto {
     }
 
     func getSquareSize(_ text: String, floorNoCeling: Bool = false) -> Int {
-        let tempDouble = Double(text.characters.count)
+        let tempDouble = Double(text.count)
         let tempRoot = tempDouble.squareRoot()
         let tempCeil = ceil(tempRoot)
         let tempFloor = floor(tempRoot)
@@ -48,7 +48,7 @@ struct Crypto {
         var plaintextSegmentsArray = [[Character]]()
 
         for each in plaintextSegments {
-            plaintextSegmentsArray.append(Array(each.characters))
+            plaintextSegmentsArray.append(Array(each))
         }
 
         var ciphertextReturn = ""
@@ -62,7 +62,7 @@ struct Crypto {
     }
 
     var normalizeCiphertext: String {
-        let sizeNormal: Int = (ciphertext.characters.count == self.size * self.size ) ? getSquareSize(self.ciphertext) : getSquareSize(self.ciphertext, floorNoCeling: true)
+        let sizeNormal: Int = (ciphertext.count == self.size * self.size ) ? getSquareSize(self.ciphertext) : getSquareSize(self.ciphertext, floorNoCeling: true)
 
         return segmentSorter(ciphertext, spacing: sizeNormal).joined(separator: " ")
     }

--- a/exercises/diamond/Sources/DiamondExample.swift
+++ b/exercises/diamond/Sources/DiamondExample.swift
@@ -1,5 +1,5 @@
 struct Diamond {
-    static let alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".characters.map { $0 }
+    static let alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ".map { $0 }
 
     static func makeDiamond(letter: Character) -> [String] {
         guard let index = alphabet.index(of: letter) else {

--- a/exercises/gigasecond/Sources/GigasecondExample.swift
+++ b/exercises/gigasecond/Sources/GigasecondExample.swift
@@ -72,10 +72,10 @@ struct Gigasecond: Equatable, CustomStringConvertible {
     }
     private func parse(_ input: String) -> tm? {
 
-        let dateTime = input.characters.split(separator: "T").map { String($0) }
+        let dateTime = input.split(separator: "T").map { String($0) }
         if dateTime.count > 1 {
-            let date = dateTime[0].characters.split(separator: "-").map { String($0) }
-            let time = dateTime[1].characters.split(separator: ":").map { String($0) }
+            let date = dateTime[0].split(separator: "-").map { String($0) }
+            let time = dateTime[1].split(separator: ":").map { String($0) }
             if date.count == 3 && time.count == date.count {
 
                 let year = Int32(date[0]) ?? 0

--- a/exercises/hamming/Sources/HammingExample.swift
+++ b/exercises/hamming/Sources/HammingExample.swift
@@ -17,7 +17,7 @@ struct Hamming {
 private func convertStringToArray(_ input: String) -> [Character] {
     var characterArray: [Character] = []
 
-    for character in input.characters {
+    for character in input {
         characterArray.append(character)
     }
 

--- a/exercises/hexadecimal/Sources/HexadecimalExample.swift
+++ b/exercises/hexadecimal/Sources/HexadecimalExample.swift
@@ -31,7 +31,7 @@ struct Hexadecimal {
         var result = 0
         var multiplier = 1
 
-        let digits = hexString.characters.map { String($0).lowercased() }.reversed()
+        let digits = hexString.map { String($0).lowercased() }.reversed()
 
         for digit in digits {
             guard let intValue = hexDigits[digit] else {

--- a/exercises/isbn-verifier/Sources/IsbnVerifierExample.swift
+++ b/exercises/isbn-verifier/Sources/IsbnVerifierExample.swift
@@ -2,15 +2,15 @@ struct IsbnVerifier {
 
     static func isValid(_ string: String) -> Bool {
         // This will be considerably less awkward after Swift 3 support is dropped
-        let cleanedString = string.characters.split(separator: "-").map(String.init).joined()
+        let cleanedString = string.split(separator: "-").map(String.init).joined()
 
-        guard cleanedString.characters.count == 10 else {
+        guard cleanedString.count == 10 else {
             return false
         }
 
         var digits = [Int]()
 
-        for character in cleanedString.characters.dropLast() {
+        for character in cleanedString.dropLast() {
             if let digit = Int(String(character)) {
                 digits.append(digit)
             } else {
@@ -18,9 +18,9 @@ struct IsbnVerifier {
             }
         }
 
-        if cleanedString.characters.last == "X" {
+        if cleanedString.last == "X" {
             digits.append(10)
-        } else if let last = cleanedString.characters.last, let digit = Int(String(last)) {
+        } else if let last = cleanedString.last, let digit = Int(String(last)) {
             digits.append(digit)
         } else {
             return false

--- a/exercises/kindergarten-garden/Sources/KindergartenGardenExample.swift
+++ b/exercises/kindergarten-garden/Sources/KindergartenGardenExample.swift
@@ -27,8 +27,8 @@ struct Garden {
         let sortedChildren = children.sorted(by: <)
         let lines = diagram.components(separatedBy: CharacterSet.newlines)
         var result = [String: [Plant]]()
-        var line1 = lines[0].characters.map { String($0) }
-        var line2 = lines[1].characters.map { String($0) }
+        var line1 = lines[0].map { String($0) }
+        var line2 = lines[1].map { String($0) }
 
         var index = 0
 

--- a/exercises/largest-series-product/Sources/LargestSeriesProductExample.swift
+++ b/exercises/largest-series-product/Sources/LargestSeriesProductExample.swift
@@ -9,7 +9,7 @@ struct NumberSeries {
     let numbers: [Int]
 
     init(_ numberString: String) throws {
-        self.numbers = try numberString.characters.map {
+        self.numbers = try numberString.map {
             guard let intValue = Int(String($0)) else {
                 throw NumberSeriesError.invalidCharacter
             }

--- a/exercises/luhn/Sources/LuhnExample.swift
+++ b/exercises/luhn/Sources/LuhnExample.swift
@@ -45,7 +45,7 @@ struct Luhn {
             return tempInt
         }
 
-        return oddIndexInt64Minus9(Array(num.characters).map { char2Int($0) })
+        return oddIndexInt64Minus9(Array(num).map { char2Int($0) })
     }
 
 }

--- a/exercises/matrix/Sources/MatrixExample.swift
+++ b/exercises/matrix/Sources/MatrixExample.swift
@@ -7,7 +7,7 @@ struct Matrix {
         var rows = [[Int]]()
         var columns = [[Int]]()
 
-        let rowItems = stringRepresentation.characters.split(separator: "\n")
+        let rowItems = stringRepresentation.split(separator: "\n")
         for item in rowItems {
             let elements = item.split(separator: " ").flatMap { Int(String($0)) }
             rows.append(elements)

--- a/exercises/meetup/Sources/MeetupExample.swift
+++ b/exercises/meetup/Sources/MeetupExample.swift
@@ -84,7 +84,7 @@ extension Date {
     init?(from: String) {
         guard let date = Date.dateFromString(from) else { return nil }
         tmDateBacking = date.tmDateBacking
-        if from.characters.count > 10 {
+        if from.count > 10 {
             self.descriptionStyle = .yyyyMMddTHHmmss
         }
     }
@@ -97,8 +97,8 @@ extension Date {
         var minute = Int32()
         var second = Int32()
 
-        let dateTime = input.characters.split(separator: "T").map { String($0) }
-        let date = dateTime[0].characters.split(separator: "-").map { String($0) }
+        let dateTime = input.split(separator: "T").map { String($0) }
+        let date = dateTime[0].split(separator: "-").map { String($0) }
         if date.count == 3 {
             year = Int32(date[0]) ?? 0
             month = Int32(date[1]) ?? 0
@@ -106,7 +106,7 @@ extension Date {
         }
 
         if dateTime.count == 2 {
-            let time = dateTime[1].characters.split(separator: ":").map { String($0) }
+            let time = dateTime[1].split(separator: ":").map { String($0) }
             if time.count == 3 {
                 hour = Int32(time[0]) ?? 0
                 minute = Int32(time[1]) ?? 0

--- a/exercises/minesweeper/Sources/MinesweeperExample.swift
+++ b/exercises/minesweeper/Sources/MinesweeperExample.swift
@@ -32,7 +32,7 @@ struct Board {
         let rowsEnumarated = rows.enumerated()
         for (i, row) in rowsEnumarated {
             var newRow = ""
-            let rowCharsEnumarated = row.characters.enumerated()
+            let rowCharsEnumarated = row.enumerated()
 
             for (j, character) in rowCharsEnumarated {
                 if character != " " {
@@ -74,12 +74,12 @@ struct Board {
     }
 
     private func validateSize() throws {
-        guard let count = rows.first?.characters.count else {
+        guard let count = rows.first?.count else {
             throw BoardError.differentLength
         }
 
         try rows.forEach {
-            guard $0.characters.count == count else {
+            guard $0.count == count else {
                 throw BoardError.differentLength
             }
         }
@@ -87,7 +87,7 @@ struct Board {
 
     private func validateData() throws {
         try rows.forEach {
-            try $0.characters.forEach {
+            try $0.forEach {
                 guard validCharacters.contains($0) else {
                     throw BoardError.invalidCharacter
                 }
@@ -124,8 +124,7 @@ private extension String {
         }
         return matches > 0
     }
-    subscript(index: Int) -> Character {
-        let index = characters.index(startIndex, offsetBy: index)
-        return self[index]
+    subscript(idx: Int) -> Character {
+        return self[index(startIndex, offsetBy: idx)]
     }
 }

--- a/exercises/nucleotide-count/Sources/NucleotideCountExample.swift
+++ b/exercises/nucleotide-count/Sources/NucleotideCountExample.swift
@@ -10,7 +10,7 @@ struct DNA {
     var nucleotideCounts: [Nucleobase: Int] = [ .adenine: 0, .thymine: 0, .cytosine: 0, .guanine: 0 ]
 
     init?(strand: String) {
-        let enumarated = strand.characters.enumerated()
+        let enumarated = strand.enumerated()
 
         for (_, value) in enumarated {
             if let possibleNucleobase = Nucleobase(rawValue: value) {

--- a/exercises/ocr-numbers/Sources/OcrNumbersExample.swift
+++ b/exercises/ocr-numbers/Sources/OcrNumbersExample.swift
@@ -21,7 +21,7 @@ struct OCR {
         case invalidNumberOfColumns
     }
     init(_ text: String) throws {
-        let lines = text.characters.split(separator: "\n").map { String($0) }
+        let lines = text.split(separator: "\n").map { String($0) }
 
         let rowCount = lines.count
 
@@ -29,14 +29,14 @@ struct OCR {
             throw OCRError.invalidNumberOfLines
         }
 
-        let columnCount = lines[0].characters.count
+        let columnCount = lines[0].count
 
         guard columnCount > 0 && columnCount % 3 == 0 else {
             throw OCRError.invalidNumberOfColumns
         }
 
         try lines.forEach {
-            guard $0.characters.count == columnCount else {
+            guard $0.count == columnCount else {
                 throw OCRError.invalidNumberOfColumns
             }
         }
@@ -55,12 +55,12 @@ struct OCR {
 
             var columnIndex = 0
 
-            while columnIndex < lines[0].characters.count {
+            while columnIndex < lines[0].count {
                 var grouping = [String]()
 
                 for line in selectedLines {
-                    let startIndex = line.characters.index(line.startIndex, offsetBy: columnIndex)
-                    let endIndex = line.characters.index(line.startIndex, offsetBy: columnIndex + 2)
+                    let startIndex = line.index(line.startIndex, offsetBy: columnIndex)
+                    let endIndex = line.index(line.startIndex, offsetBy: columnIndex + 2)
                     grouping.append(String(line[startIndex...endIndex]))
 
                 }

--- a/exercises/octal/Sources/OctalExample.swift
+++ b/exercises/octal/Sources/OctalExample.swift
@@ -20,7 +20,7 @@ struct Octal {
     }
 
     private func oct2int(_ input: String) -> Int {
-        let orderedInput = Array(input.characters.reversed())
+        let orderedInput = Array(input.reversed())
         var tempInt: Int = 0
         for (inx, each) in orderedInput.enumerated() {
             let tempCharInt = Int("\(each)") ?? 0

--- a/exercises/palindrome-products/Sources/PalindromeProductsExample.swift
+++ b/exercises/palindrome-products/Sources/PalindromeProductsExample.swift
@@ -3,10 +3,11 @@ import Dispatch
 
 private extension String {
 
-    var length: Int { return self.characters.count }
+    var length: Int { return self.count }
 
     func reverse() -> String {
-        return characters.reversed().map { String($0) }.joined()
+        return reversed().map { String($0) }.joined()
+        return String(reversed())
     }
 }
 

--- a/exercises/pangram/Sources/PangramExample.swift
+++ b/exercises/pangram/Sources/PangramExample.swift
@@ -6,7 +6,7 @@ struct Pangram {
     static func isPangram(_ text: String) -> Bool {
         let lowercasedText = text.folding(options: .diacriticInsensitive, locale: .current).lowercased()
 
-        for letter in "abcdefghijklmnopqrstuvwxyz".characters {
+        for letter in "abcdefghijklmnopqrstuvwxyz" {
             if lowercasedText.contains(String(letter)) == false {
                 return false
             }

--- a/exercises/phone-number/Sources/PhoneNumberExample.swift
+++ b/exercises/phone-number/Sources/PhoneNumberExample.swift
@@ -3,8 +3,8 @@ import Foundation
 private extension String {
     subscript (range: CountableClosedRange<Int>) -> String {
         get {
-            let start = characters.index(startIndex, offsetBy: range.lowerBound)
-            let end = characters.index(start, offsetBy: range.upperBound - range.lowerBound)
+            let start = index(startIndex, offsetBy: range.lowerBound)
+            let end = index(start, offsetBy: range.upperBound - range.lowerBound)
 
             return String(self[start...end])
         }
@@ -17,7 +17,7 @@ private extension String {
 
 private extension Character {
     var isDigit: Bool {
-        return "0123456789".characters.contains(self)
+        return "0123456789".contains(self)
     }
 }
 
@@ -27,7 +27,7 @@ struct PhoneNumber: CustomStringConvertible {
     init(_ startingNumber: String) {
         let digits = startingNumber.onlyDigits
 
-        switch digits.characters.count {
+        switch digits.count {
         case 10:
             number = digits
         case 11 where digits.hasPrefix("1"):

--- a/exercises/pig-latin/Sources/PigLatinExample.swift
+++ b/exercises/pig-latin/Sources/PigLatinExample.swift
@@ -2,13 +2,13 @@ import Foundation
 
 private extension String {
     func substringFromIndexInt(_ indx: Int) -> String {
-        let index = self.characters.index(self.startIndex, offsetBy: indx)
+        let index = self.index(self.startIndex, offsetBy: indx)
         return self.substring(from: index)
     }
 
     func substringWithRangeInt(_ intRange: Range<Int>) -> String {
-        let start = self.characters.index(self.startIndex, offsetBy: intRange.lowerBound)
-        let end = self.characters.index(self.startIndex, offsetBy: intRange.upperBound)
+        let start = self.index(self.startIndex, offsetBy: intRange.lowerBound)
+        let end = self.index(self.startIndex, offsetBy: intRange.upperBound)
         return self.substring(with: start..<end)
     }
 }
@@ -30,7 +30,7 @@ struct PigLatin {
         }
 
         func wordStartsWithConsonantAndQu(_ word: String) -> Bool {
-            let index = word.characters.index(word.startIndex, offsetBy: 1)
+            let index = word.index(word.startIndex, offsetBy: 1)
             return word.substring(from: index).hasPrefix("qu")
         }
 

--- a/exercises/poker/Sources/PokerExample.swift
+++ b/exercises/poker/Sources/PokerExample.swift
@@ -7,11 +7,11 @@ private extension String {
     }
     // Returns the Rank part of the card
     func head() -> String {
-        return self.substring(to: self.characters.index(before: self.endIndex))
+        return self.substring(to: self.index(before: self.endIndex))
     }
     // Return the Suit part of the card
     func tail() -> String {
-        return self.substring(from: self.characters.index(before: self.endIndex))
+        return self.substring(from: self.index(before: self.endIndex))
     }
 }
 

--- a/exercises/protein-translation/Sources/ProteinTranslationExample.swift
+++ b/exercises/protein-translation/Sources/ProteinTranslationExample.swift
@@ -40,13 +40,13 @@ struct ProteinTranslation {
         var result = [String]()
 
         while !strand.isEmpty {
-            let codon = String(strand.characters.prefix(3))
+            let codon = String(strand.prefix(3))
             let translation = try translationOfCodon(codon)
             if translation == "STOP" {
                 return result
             }
             result.append(translation)
-            strand = String(strand.characters.dropFirst(3))
+            strand = String(strand.dropFirst(3))
         }
 
         return result

--- a/exercises/rna-transcription/Sources/RnaTranscriptionExample.swift
+++ b/exercises/rna-transcription/Sources/RnaTranscriptionExample.swift
@@ -17,7 +17,7 @@ struct Nucleotide {
 
     private func transcribe(_ dict: [Character: String]) throws -> String {
         var tempText = ""
-        for each in self.value.characters {
+        for each in self.value {
             if dict[each] == nil {
                 throw TranscriptionError.invalidNucleotide("\(each) is not a valid Nucleotide")
             }

--- a/exercises/robot-name/Sources/RobotNameExample.swift
+++ b/exercises/robot-name/Sources/RobotNameExample.swift
@@ -21,7 +21,7 @@ struct Robot {
 
 private func convertStringToStringArray(_ input: String) -> [String] {
     var characterArray: [String] = []
-    for character in input.characters {
+    for character in input {
         characterArray.append("\(character)")
     }
     return characterArray

--- a/exercises/robot-simulator/Sources/RobotSimulatorExample.swift
+++ b/exercises/robot-simulator/Sources/RobotSimulatorExample.swift
@@ -63,7 +63,7 @@ struct SimulatedRobot {
     func instructions(_ instructions: String) -> [Instruction] {
         var result = [Instruction]()
 
-        let characters = instructions.characters.map { String($0) }
+        let characters = instructions.map { String($0) }
 
         for character in characters {
             if let instruction = Instruction(rawValue: character) {

--- a/exercises/run-length-encoding/Sources/RunLengthEncodingExample.swift
+++ b/exercises/run-length-encoding/Sources/RunLengthEncodingExample.swift
@@ -3,10 +3,10 @@ struct RunLengthEncoding {
     static func encode(_ input: String) -> String {
         var result = ""
 
-        var lastCharacter = input.characters.first!
+        var lastCharacter = input.first!
         var count = 0
 
-        for (index, character) in input.characters.enumerated() {
+        for (index, character) in input.enumerated() {
             if character == lastCharacter {
                 count += 1
             }
@@ -26,7 +26,7 @@ struct RunLengthEncoding {
                 addCharacter()
             }
 
-            let isFinal = index == input.characters.count - 1
+            let isFinal = index == input.count - 1
 
             if isFinal {
                 addCharacter()
@@ -41,7 +41,7 @@ struct RunLengthEncoding {
 
         var multiplier: Int?
 
-        for character in input.characters {
+        for character in input {
             if let number = Int(String(character)) {
                 if let currentMultiplier = multiplier {
                     multiplier = currentMultiplier * 10 + number

--- a/exercises/saddle-points/Sources/SaddlePointsExample.swift
+++ b/exercises/saddle-points/Sources/SaddlePointsExample.swift
@@ -7,10 +7,10 @@ struct SaddlePointsMatrix {
     init(_ matrix: String) {
         var rows = [[Int]]()
 
-        let rowItems = matrix.characters.split(separator: "\n").map { String($0) }
+        let rowItems = matrix.split(separator: "\n").map { String($0) }
 
         for row in rowItems {
-            let rowItems = row.characters.split(separator: " ").map { Int(String($0)) ?? 0 }
+            let rowItems = row.split(separator: " ").map { Int(String($0)) ?? 0 }
             rows.append(rowItems)
         }
 

--- a/exercises/scrabble-score/Sources/ScrabbleScoreExample.swift
+++ b/exercises/scrabble-score/Sources/ScrabbleScoreExample.swift
@@ -14,7 +14,7 @@ private extension String {
 
     private func stripCharacters(_ charsToRemove: String) -> String {
         var returnString = ""
-        self.characters.forEach {
+        self.forEach {
             if !charsToRemove.containsCustom($0) {
                 returnString.append($0)
             }}
@@ -40,7 +40,7 @@ struct Scrabble {
         }
 
         var count: Int = 0
-        for each in input.lowercasedCustom().characters {
+        for each in input.lowercasedCustom() {
             count += letterScores[String(each)] ?? 0
         }
         return count

--- a/exercises/series/Sources/SeriesExample.swift
+++ b/exercises/series/Sources/SeriesExample.swift
@@ -7,7 +7,7 @@ struct Series {
     }
 
     func slices(_ chunkSize: Int) -> [[Int]] {
-        var numberStringArray = Array(numberString.characters).map { Int("\($0)") ?? 0 }
+        var numberStringArray = Array(numberString).map { Int("\($0)") ?? 0 }
         let count = numberStringArray.count
         var start = 0
         var end = chunkSize

--- a/exercises/simple-cipher/Sources/SimpleCipherExample.swift
+++ b/exercises/simple-cipher/Sources/SimpleCipherExample.swift
@@ -17,9 +17,9 @@ func arc4random_uniform(_ input: Int) -> Int {
 
 public struct Cipher {
     private let abc = "abcdefghijklmnopqrstuvwxyz"
-    private var alphabet: [Character] { return Array(abc.characters) }
+    private var alphabet: [Character] { return Array(abc) }
     private(set) var key: String = ""
-    private var keyArray: [Character] { return Array(key.characters) }
+    private var keyArray: [Character] { return Array(key) }
     private func randomKeySet() -> String {
         var tempKey = ""
         for _ in (0..<100).enumerated() {
@@ -43,7 +43,7 @@ public struct Cipher {
     }
     func isLowerCaseAlfabet(_ inkey: String) -> Bool {
         var valid = true
-        inkey.characters.forEach {
+        inkey.forEach {
 
             if "abcdefghijklmnopqrstuvwxyz".contains(String($0)) == false {
                 valid = false
@@ -52,7 +52,7 @@ public struct Cipher {
         return valid
     }
     func encode(_ plaintext: String) -> String {
-        let plainTextArray = Array(plaintext.characters)
+        let plainTextArray = Array(plaintext)
 
         func encodeCharacter(_ plaintext: String, idx: Int) -> Character {
             //let plainTextArray = Array(plaintext) // hack for subscript support for Strings
@@ -73,7 +73,7 @@ public struct Cipher {
     }
 
     func decode(_ ciphertext: String) -> String {
-        let cipherTextArray = Array(ciphertext.characters)
+        let cipherTextArray = Array(ciphertext)
 
         func decodeCharacter(_ ciphertext: String, idx: Int) -> Character {
             //let cipherTextArray = Array(ciphertext) // no native subscript for String

--- a/exercises/simple-cipher/Tests/SimpleCipherTests/SimpleCipherTests.swift
+++ b/exercises/simple-cipher/Tests/SimpleCipherTests/SimpleCipherTests.swift
@@ -5,14 +5,14 @@ class SimpleCipherTests: XCTestCase {
     func testCipherEncode() {
         let cipher = Cipher()
         let plaintext = "aaaaaaaaaa"
-        let expected  = cipher.key.substring(to: cipher.key.characters.index(cipher.key.startIndex, offsetBy: 10))
+        let expected  = cipher.key.substring(to: cipher.key.index(cipher.key.startIndex, offsetBy: 10))
         XCTAssertEqual(expected, cipher.encode(plaintext))
     }
 
     func testCipherDecode() {
         let cipher = Cipher()
         let plaintext = "aaaaaaaaaa"
-        let expected  = cipher.key.substring(to: cipher.key.characters.index(cipher.key.startIndex, offsetBy: 10))
+        let expected  = cipher.key.substring(to: cipher.key.index(cipher.key.startIndex, offsetBy: 10))
         XCTAssertEqual(plaintext, cipher.decode(expected))
     }
 

--- a/exercises/tournament/Sources/TournamentExample.swift
+++ b/exercises/tournament/Sources/TournamentExample.swift
@@ -5,21 +5,21 @@ private extension String {
     func trimWhiteSpace() -> String {
         let removeSpaces = trimCharacters(" ", sourceText: self)
         if removeSpaces.hasSuffix("\n") {
-            return String(removeSpaces.characters.dropLast())
+            return String(removeSpaces.dropLast())
         }
         return removeSpaces
 
     }
 
     func trimCharacters(_ charToTrim: Character, sourceText: String) -> String {
-        var editCharacterView = sourceText.characters
+        var editCharacterView = Array(sourceText)
         var editString = String(editCharacterView)
 
-        let trimFirst  = sourceText.characters.first == charToTrim
-        let trimLast   = sourceText.characters.last == charToTrim
+        let trimFirst  = sourceText.first == charToTrim
+        let trimLast   = sourceText.last == charToTrim
 
-        if trimFirst { editCharacterView  = editCharacterView.dropFirst() }
-        if trimLast { editCharacterView  = editCharacterView.dropLast() }
+        if trimFirst { editCharacterView  = Array(editCharacterView.dropFirst()) }
+        if trimLast { editCharacterView  = Array(editCharacterView.dropLast()) }
 
         if trimFirst || trimLast == true {
             editString = trimCharacters(charToTrim, sourceText: String(editCharacterView))
@@ -94,12 +94,12 @@ struct Tournament {
         func formarter (_ team: String, mp: String, w: String, d: String, l: String, p: String) -> String {
 
             func wsChars(_ text: String, spacing: Int = 31) -> String {
-                return repeatElement( " ", count: abs(spacing - Array(text.characters).count)).joined(separator: "")
+                return repeatElement( " ", count: abs(spacing - Array(text).count)).joined(separator: "")
 
             }
 
             func spacing(_ text: String, columnWith: Int = 4) -> String {
-                let textCount = Array(text.characters).count
+                let textCount = Array(text).count
                 let space = Int(round(Double(textCount) / Double(columnWith)))
 
                 return wsChars(text, spacing: columnWith - space - textCount) + text + wsChars(text, spacing: space )
@@ -161,7 +161,7 @@ struct Tournament {
         var outcome: Outcome = Outcome.err
 
         // alternative to .componentsSeparatedByString
-        let textArrayLines = inStream.characters.split { $0 == "\n" }.map { String($0) }
+        let textArrayLines = inStream.split { $0 == "\n" }.map { String($0) }
 
         for line in textArrayLines {
             let parts = line.trimWhiteSpace().components(separatedBy: ";")

--- a/exercises/transpose/Sources/TransposeExample.swift
+++ b/exercises/transpose/Sources/TransposeExample.swift
@@ -2,7 +2,7 @@ import Foundation
 
 struct Transpose {
     static func transpose(_ input: [String]) -> [String] {
-        let maxLineLength = input.map { $0.characters.count }.max()
+        let maxLineLength = input.map { $0.count }.max()
 
         guard let maxLength = maxLineLength else {
             return []

--- a/exercises/trinary/Sources/TrinaryExample.swift
+++ b/exercises/trinary/Sources/TrinaryExample.swift
@@ -17,7 +17,7 @@ struct Trinary {
     }
 
     private func tri2int(_ input: String) -> Int {
-        let orderedInput = Array(input.characters.reversed())
+        let orderedInput = Array(input.reversed())
         let enumarated = orderedInput.enumerated()
 
         var tempInt: Int = 0

--- a/exercises/word-count/Sources/WordCountExample.swift
+++ b/exercises/word-count/Sources/WordCountExample.swift
@@ -1,11 +1,11 @@
 struct WordCount {
 
     func splitStringToArray(_ inString: String) -> [String] {
-        return inString.characters.split(whereSeparator: { splitAt($0) }).map { String($0) }
+        return inString.split(whereSeparator: { splitAt($0) }).map { String($0) }
     }
 
     func splitAt(_ characterToCompare: Character, charToSplitAt: String = " !&$%^&,:") -> Bool {
-        for each in charToSplitAt.characters where each == characterToCompare {
+        for each in charToSplitAt where each == characterToCompare {
             return true
         }
         return false

--- a/exercises/wordy/Sources/WordyExample.swift
+++ b/exercises/wordy/Sources/WordyExample.swift
@@ -5,20 +5,20 @@ private extension String {
     func trimWhiteSpace() -> String {
         let removeSpaces = trimCharacters(" ", sourceText: self)
         if removeSpaces.hasSuffix("\n") {
-            return String(removeSpaces.characters.dropLast())
+            return String(removeSpaces.dropLast())
         }
         return  removeSpaces
     }
 
     func trimCharacters(_ charToTrim: Character, sourceText: String) -> String {
-        var editCharacterView = sourceText.characters
+        var editCharacterView = Array(sourceText)
         var editString = String(editCharacterView)
 
-        let trimFirst  = sourceText.characters.first == charToTrim
-        let trimLast   = sourceText.characters.last == charToTrim
+        let trimFirst  = sourceText.first == charToTrim
+        let trimLast   = sourceText.last == charToTrim
 
-        if trimFirst { editCharacterView  = editCharacterView.dropFirst() }
-        if trimLast { editCharacterView  = editCharacterView.dropLast() }
+        if trimFirst { editCharacterView  = Array(editCharacterView.dropFirst()) }
+        if trimLast { editCharacterView  = Array(editCharacterView.dropLast()) }
 
         if trimFirst || trimLast == true {
             editString = trimCharacters(charToTrim, sourceText: String(editCharacterView))
@@ -101,7 +101,7 @@ struct WordProblem {
         }
 
         func checkCharInSet(_ input: Character) -> Bool {
-            let temp = " 0987654321+-*/".characters.index(of: input)
+            let temp = " 0987654321+-*/".index(of: input)
 
             if temp == nil {
                 return false
@@ -109,7 +109,7 @@ struct WordProblem {
                 return true}
         }
 
-        var newTextIn =  Array(textInp.characters)
+        var newTextIn =  Array(textInp)
         newTextIn = newTextIn.filter(checkCharInSet)
         let newTextInString: [String] = newTextIn.map { String($0) }
         return newTextInString.joined(separator: "").trimWhiteSpace()


### PR DESCRIPTION
In latest version of Swift, `.characters` property is deprecated. This patch helps remove those deprecation warnings.

> Please note that code can be refactored in few places using the latest Swift's String APIs. This can be done in a separate PR.