### PR TITLE
Fix remaining warnings after upgrading to Swift 4.2

### DIFF
--- a/exercises/acronym/Sources/Acronym/AcronymExample.swift
+++ b/exercises/acronym/Sources/Acronym/AcronymExample.swift
@@ -5,7 +5,7 @@ private extension String {
     func substringWithRangeInt(_ intRange: CountableRange<Int>) -> String {
         let start = self.index(self.startIndex, offsetBy: intRange.lowerBound)
         let end = self.index(self.startIndex, offsetBy: intRange.upperBound)
-        return self.substring(with: start..<end)
+        return String(self[start..<end])
     }
 
     func substringWithRangeInt(_ start: Int, end: Int) -> String {

--- a/exercises/bowling/Sources/Bowling/BowlingExample.swift
+++ b/exercises/bowling/Sources/Bowling/BowlingExample.swift
@@ -47,11 +47,11 @@ struct Bowling {
 
     private func scoreFrame(_ frame: [Int], index: Int) -> Int {
         let strikeOrSpare = [frame.first, frame.reduce(0, +)]
-            .flatMap { $0 }
+            .compactMap { $0 }
             .contains(maxPins)
 
         if strikeOrSpare {
-            let scores = [scoreCard[index], scoreCard[index + 1], scoreCard[index + 2]].flatMap { $0 }.flatMap { $0 }
+            let scores = [scoreCard[index], scoreCard[index + 1], scoreCard[index + 2]].compactMap { $0 }.flatMap { $0 }
             let firstThree = scores[0...2]
 
             return firstThree.reduce(0, +)

--- a/exercises/circular-buffer/Sources/CircularBuffer/CircularBufferExample.swift
+++ b/exercises/circular-buffer/Sources/CircularBuffer/CircularBufferExample.swift
@@ -12,11 +12,11 @@ struct CircularBuffer<T: Equatable> {
     var readPoint = 0
 
     private var isFull: Bool {
-        return buffer.flatMap { $0 }.count >= capacity
+        return buffer.compactMap { $0 }.count >= capacity
     }
 
     private var isEmpty: Bool {
-        return buffer.flatMap { $0 }.isEmpty
+        return buffer.compactMap { $0 }.isEmpty
     }
 
     init(capacity: Int) {

--- a/exercises/flatten-array/Sources/FlattenArray/FlattenArrayExample.swift
+++ b/exercises/flatten-array/Sources/FlattenArray/FlattenArrayExample.swift
@@ -6,7 +6,7 @@ func flattenArray<T>(_ list: [Any?]) -> [T] {
 
     func extractArrayElements(array: [Any?]) {
 
-        for element in array.flatMap({ $0 }) {
+        for element in array.compactMap({ $0 }) {
 
             let anyObjectArray = element as? [Any?]
 

--- a/exercises/matrix/Sources/Matrix/MatrixExample.swift
+++ b/exercises/matrix/Sources/Matrix/MatrixExample.swift
@@ -9,7 +9,7 @@ struct Matrix {
 
         let rowItems = stringRepresentation.split(separator: "\n")
         for item in rowItems {
-            let elements = item.split(separator: " ").flatMap { Int(String($0)) }
+            let elements = item.split(separator: " ").compactMap { Int(String($0)) }
             rows.append(elements)
         }
         for i in 0 ..< rows[0].count {

--- a/exercises/palindrome-products/Sources/PalindromeProducts/PalindromeProductsExample.swift
+++ b/exercises/palindrome-products/Sources/PalindromeProducts/PalindromeProductsExample.swift
@@ -6,7 +6,6 @@ private extension String {
     var length: Int { return self.count }
 
     func reverse() -> String {
-        return reversed().map { String($0) }.joined()
         return String(reversed())
     }
 }

--- a/exercises/phone-number/Sources/PhoneNumber/PhoneNumberExample.swift
+++ b/exercises/phone-number/Sources/PhoneNumber/PhoneNumberExample.swift
@@ -11,7 +11,7 @@ private extension String {
     }
 
     var onlyDigits: String {
-        return String(characters.filter { $0.isDigit })
+        return String(filter({ $0.isDigit }))
     }
 }
 

--- a/exercises/pig-latin/Sources/PigLatin/PigLatinExample.swift
+++ b/exercises/pig-latin/Sources/PigLatin/PigLatinExample.swift
@@ -3,13 +3,13 @@ import Foundation
 private extension String {
     func substringFromIndexInt(_ indx: Int) -> String {
         let index = self.index(self.startIndex, offsetBy: indx)
-        return self.substring(from: index)
+        return String(self[index...])
     }
 
     func substringWithRangeInt(_ intRange: Range<Int>) -> String {
         let start = self.index(self.startIndex, offsetBy: intRange.lowerBound)
         let end = self.index(self.startIndex, offsetBy: intRange.upperBound)
-        return self.substring(with: start..<end)
+        return String(self[start..<end])
     }
 }
 
@@ -31,7 +31,7 @@ struct PigLatin {
 
         func wordStartsWithConsonantAndQu(_ word: String) -> Bool {
             let index = word.index(word.startIndex, offsetBy: 1)
-            return word.substring(from: index).hasPrefix("qu")
+            return word[index...].hasPrefix("qu")
         }
 
         if wordStartsWithVowelLike(word) { return word + "ay" }

--- a/exercises/poker/Sources/Poker/PokerExample.swift
+++ b/exercises/poker/Sources/Poker/PokerExample.swift
@@ -7,11 +7,12 @@ private extension String {
     }
     // Returns the Rank part of the card
     func head() -> String {
-        return self.substring(to: self.index(before: self.endIndex))
+        return String(self[..<index(before: endIndex)])
     }
     // Return the Suit part of the card
     func tail() -> String {
-        return self.substring(from: self.index(before: self.endIndex))
+        //return self.substring(from: ))
+        return String(self[index(before: endIndex)..<endIndex])
     }
 }
 

--- a/exercises/simple-cipher/Tests/SimpleCipherTests/SimpleCipherTests.swift
+++ b/exercises/simple-cipher/Tests/SimpleCipherTests/SimpleCipherTests.swift
@@ -5,14 +5,14 @@ class SimpleCipherTests: XCTestCase {
     func testCipherEncode() {
         let cipher = Cipher()
         let plaintext = "aaaaaaaaaa"
-        let expected  = cipher.key.substring(to: cipher.key.index(cipher.key.startIndex, offsetBy: 10))
+        let expected  = String(cipher.key[..<cipher.key.index(cipher.key.startIndex, offsetBy: 10)])
         XCTAssertEqual(expected, cipher.encode(plaintext))
     }
 
     func testCipherDecode() {
         let cipher = Cipher()
         let plaintext = "aaaaaaaaaa"
-        let expected  = cipher.key.substring(to: cipher.key.index(cipher.key.startIndex, offsetBy: 10))
+        let expected  = String(cipher.key[..<cipher.key.index(cipher.key.startIndex, offsetBy: 10)])
         XCTAssertEqual(plaintext, cipher.decode(expected))
     }
 


### PR DESCRIPTION
These warnings were missed in my initial Swift 4.2 migration PR.