### PR TITLE
Revise Twelve Days exercise

### DIFF
--- a/exercises/twelve-days/Sources/TwelveDays/TwelveDaysExample.swift
+++ b/exercises/twelve-days/Sources/TwelveDays/TwelveDaysExample.swift
@@ -1,24 +1,39 @@
 struct TwelveDaysSong {
 
+    private static let ordinals = ["first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eighth", "ninth", "tenth", "eleventh", "twelfth"]
+
+    private static let gifts = ["a Partridge in a Pear Tree", "two Turtle Doves", "three French Hens", "four Calling Birds", "five Gold Rings", "six Geese-a-Laying", "seven Swans-a-Swimming", "eight Maids-a-Milking", "nine Ladies Dancing", "ten Lords-a-Leaping", "eleven Pipers Piping", "twelve Drummers Drumming"]
+
+    static func verse(_ verseNumber: Int) -> String {
+        let ordinal = ordinals[verseNumber - 1]
+        var verse = "On the \(ordinal) day of Christmas my true love gave to me: "
+        verse += gifts(forNumber: verseNumber)
+
+        return verse
+    }
+
+    static func verses(_ start: Int, _ end: Int) -> String {
+        var verses = [String]()
+        for i in start...end {
+            verses.append(verse(i))
+        }
+
+        return verses.joined(separator: "\n")
+    }
+
     static func sing() -> String {
         return verses(1, 12)
     }
 
-    static func verses(_ start: Int, _ end: Int) -> String {
-        var string2return = ""
-        for each in start...end {
-            string2return += verse(each) + "\n"
+    private static func gifts(forNumber number: Int) -> String {
+        let gift = gifts[number - 1]
+
+        if number == 1 {
+            return "\(gift)."
+        } else if number == 2 {
+            return "\(gift), and \(gifts(forNumber: number - 1))"
+        } else {
+            return "\(gift), \(gifts(forNumber: number - 1))"
         }
-
-        return string2return
     }
-    static func verse(_ number: Int) -> String {
-        let dictionary = [
-            1: "On the first day of Christmas my true love gave to me, a Partridge in a Pear Tree.\n", 2: "On the second day of Christmas my true love gave to me, two Turtle Doves, and a Partridge in a Pear Tree.\n", 3: "On the third day of Christmas my true love gave to me, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n", 4: "On the fourth day of Christmas my true love gave to me, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n", 5: "On the fifth day of Christmas my true love gave to me, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n", 6: "On the sixth day of Christmas my true love gave to me, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n", 7: "On the seventh day of Christmas my true love gave to me, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n", 8: "On the eighth day of Christmas my true love gave to me, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n", 9: "On the ninth day of Christmas my true love gave to me, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n", 10: "On the tenth day of Christmas my true love gave to me, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n", 11: "On the eleventh day of Christmas my true love gave to me, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n", 12: "On the twelfth day of Christmas my true love gave to me, twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
-        ]
-
-        return dictionary[number] ?? ""
-
-    }
-
 }

--- a/exercises/twelve-days/Tests/TwelveDaysTests/TwelveDaysTests.swift
+++ b/exercises/twelve-days/Tests/TwelveDaysTests/TwelveDaysTests.swift
@@ -3,89 +3,116 @@ import XCTest
 
 class TwelveDaysTests: XCTestCase {
     func testVerse1() {
-        let expected = "On the first day of Christmas my true love gave to me, a Partridge in a Pear Tree.\n"
+        let expected = "On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree."
         let result = TwelveDaysSong.verse(1)
         XCTAssertEqual(expected, result)
     }
 
     func testVerse2() {
-        let expected = "On the second day of Christmas my true love gave to me, two Turtle Doves, and a Partridge in a Pear Tree.\n"
+        let expected = "On the second day of Christmas my true love gave to me: two Turtle Doves, and a Partridge in a Pear Tree."
         let result = TwelveDaysSong.verse(2)
         XCTAssertEqual(expected, result)
     }
 
     func testVerse3() {
-        let expected = "On the third day of Christmas my true love gave to me, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
+        let expected = "On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
         let result = TwelveDaysSong.verse(3)
         XCTAssertEqual(expected, result)
     }
 
     func testVerse4() {
-        let expected = "On the fourth day of Christmas my true love gave to me, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
+        let expected = "On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
         let result = TwelveDaysSong.verse(4)
         XCTAssertEqual(expected, result)
     }
 
     func testVerse5() {
-        let expected = "On the fifth day of Christmas my true love gave to me, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
+        let expected = "On the fifth day of Christmas my true love gave to me: five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
         let result = TwelveDaysSong.verse(5)
         XCTAssertEqual(expected, result)
     }
 
     func testVerse6() {
-        let expected = "On the sixth day of Christmas my true love gave to me, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
+        let expected = "On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
         let result = TwelveDaysSong.verse(6)
         XCTAssertEqual(expected, result)
     }
 
     func testVerse7() {
-        let expected = "On the seventh day of Christmas my true love gave to me, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
+        let expected = "On the seventh day of Christmas my true love gave to me: seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
         let result = TwelveDaysSong.verse(7)
         XCTAssertEqual(expected, result)
     }
 
     func testVerse8() {
-        let expected = "On the eighth day of Christmas my true love gave to me, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
+        let expected = "On the eighth day of Christmas my true love gave to me: eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
         let result = TwelveDaysSong.verse(8)
         XCTAssertEqual(expected, result)
     }
 
     func testVerse9() {
-        let expected = "On the ninth day of Christmas my true love gave to me, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
+        let expected = "On the ninth day of Christmas my true love gave to me: nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
         let result = TwelveDaysSong.verse(9)
         XCTAssertEqual(expected, result)
     }
 
     func testVerse10() {
-        let expected = "On the tenth day of Christmas my true love gave to me, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
+        let expected = "On the tenth day of Christmas my true love gave to me: ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
         let result = TwelveDaysSong.verse(10)
         XCTAssertEqual(expected, result)
     }
 
     func testVerse11() {
-        let expected = "On the eleventh day of Christmas my true love gave to me, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
+        let expected = "On the eleventh day of Christmas my true love gave to me: eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
         let result = TwelveDaysSong.verse(11)
         XCTAssertEqual(expected, result)
     }
 
     func testVerse12() {
-        let expected = "On the twelfth day of Christmas my true love gave to me, twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n"
+        let expected = "On the twelfth day of Christmas my true love gave to me: twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree."
         let result = TwelveDaysSong.verse(12)
         XCTAssertEqual(expected, result)
     }
 
-    func testMultipleVerses() {
-        let expected = (
-            "On the first day of Christmas my true love gave to me, a Partridge in a Pear Tree.\n\n" +
-                "On the second day of Christmas my true love gave to me, two Turtle Doves, and a Partridge in a Pear Tree.\n\n" +
-            "On the third day of Christmas my true love gave to me, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.\n\n")
+    func testFirstThreeVerses() {
+        let expected =
+        """
+        On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree.
+        On the second day of Christmas my true love gave to me: two Turtle Doves, and a Partridge in a Pear Tree.
+        On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+        """
         let result = TwelveDaysSong.verses(1, 3)
         XCTAssertEqual(expected, result)
     }
 
-    func testTheWholeSong() {
+    func testThreeVersesFromMiddle() {
+        let expected =
+        """
+        On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+        On the fifth day of Christmas my true love gave to me: five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+        On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+        """
+        let result = TwelveDaysSong.verses(4, 6)
+        XCTAssertEqual(expected, result)
+    }
 
-        XCTAssertEqual(TwelveDaysSong.verses(1, 12), TwelveDaysSong.sing())
+    func testTheWholeSong() {
+        let expected =
+        """
+        On the first day of Christmas my true love gave to me: a Partridge in a Pear Tree.
+        On the second day of Christmas my true love gave to me: two Turtle Doves, and a Partridge in a Pear Tree.
+        On the third day of Christmas my true love gave to me: three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+        On the fourth day of Christmas my true love gave to me: four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+        On the fifth day of Christmas my true love gave to me: five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+        On the sixth day of Christmas my true love gave to me: six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+        On the seventh day of Christmas my true love gave to me: seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+        On the eighth day of Christmas my true love gave to me: eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+        On the ninth day of Christmas my true love gave to me: nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+        On the tenth day of Christmas my true love gave to me: ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+        On the eleventh day of Christmas my true love gave to me: eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+        On the twelfth day of Christmas my true love gave to me: twelve Drummers Drumming, eleven Pipers Piping, ten Lords-a-Leaping, nine Ladies Dancing, eight Maids-a-Milking, seven Swans-a-Swimming, six Geese-a-Laying, five Gold Rings, four Calling Birds, three French Hens, two Turtle Doves, and a Partridge in a Pear Tree.
+        """
+        XCTAssertEqual(expected, TwelveDaysSong.sing())
 
     }
 
@@ -103,7 +130,8 @@ class TwelveDaysTests: XCTestCase {
             ("testVerse10", testVerse10),
             ("testVerse11", testVerse11),
             ("testVerse12", testVerse12),
-            ("testMultipleVerses", testMultipleVerses),
+            ("testFirstThreeVerses", testFirstThreeVerses),
+            ("testThreeVersesFromMiddle", testThreeVersesFromMiddle),
             ("testTheWholeSong", testTheWholeSong),
         ]
     }


### PR DESCRIPTION
* Fixes issue #370 by matching tests to new specification
* Use multi-line string literals (not available when originally written)
* Improve example solution with a more efficient one