### PR TITLE
Remove test cases that break tie by suit

### DIFF
--- a/exercises/poker/Tests/PokerTests/PokerTests.swift
+++ b/exercises/poker/Tests/PokerTests/PokerTests.swift
@@ -216,7 +216,7 @@ class PokerTests: XCTestCase {
                     "Q♢ K♢ J♢ 10♢ A♢"
                 ],
                 best:  "Q♢ K♢ J♢ 10♢ A♢"
-            ),
+            )
         ]
 
         invalidTestCases  =

--- a/exercises/poker/Tests/PokerTests/PokerTests.swift
+++ b/exercises/poker/Tests/PokerTests/PokerTests.swift
@@ -217,21 +217,6 @@ class PokerTests: XCTestCase {
                 ],
                 best:  "Q♢ K♢ J♢ 10♢ A♢"
             ),
-            (
-                name:  "tie for best pair: brake tide by suit",
-                hands: ["4♡ 2♡ 5♧ 4♢ 10♡", "4♧ 10♢ 5♤ 2♤ 4♤"],
-                best:  "4♡ 2♡ 5♧ 4♢ 10♡"
-            ),
-            (
-                name: "tie of three: brake tide by suit",
-                hands: [
-                    "A♡ 2♡ 3♡ 4♡ 5♡",
-                    "A♤ 2♤ 3♤ 4♤ 5♤",
-                    "5♧ 4♧ 3♧ 2♧ A♧",
-                    "A♢ 2♢ 6♢ 4♢ 5♢"
-                ],
-                best:  "A♤ 2♤ 3♤ 4♤ 5♤"
-            )
         ]
 
         invalidTestCases  =


### PR DESCRIPTION
**Proposal:** Remove test cases that enforce a winner among identically hands in different suits.

**Reasoning:** According to the rules of poker, there is no ranking of suits. Two equal hands with differing suits are considered to tie.

[Source 1 - World Series of Poker:](https://www.wsop.com/poker-hands/)
> The suits are all of equal value - no suit is higher than any other suit.

[Source 2 - Wikipedia (referenced in the exercise description):](https://en.wikipedia.org/wiki/List_of_poker_hands)
> Suits are not ranked, so hands that differ by suit alone are of equal rank. 

**Alternatives:** We could add tests to test for ties, perhaps by having the bestHands method return nil in such cases.