### PR TITLE
Added two tests and removed force-unwrapping in test cases

### DIFF
--- a/exercises/nucleotide-count/.gitignore
+++ b/exercises/nucleotide-count/.gitignore
@@ -2,3 +2,4 @@
 /.build
 /Packages
 /*.xcodeproj
+.swiftpm

--- a/exercises/nucleotide-count/Tests/NucleotideCountTests/NucleotideCountTests.swift
+++ b/exercises/nucleotide-count/Tests/NucleotideCountTests/NucleotideCountTests.swift
@@ -2,55 +2,68 @@ import XCTest
 @testable import NucleotideCount
 
 class NucleotideCountTests: XCTestCase {
-    func testEmptyDNAStringHasNoAdenosine() {
-        let dna = DNA(strand: "")!
+    func testEmptyDNAStringHasNoAdenosine() throws {
+        let dna = try XCTUnwrap(DNA(strand: ""), "Empty strands are valid strands and should not return nil")
         let result = dna.count("A")
         let expected = 0
         XCTAssertEqual(result, expected)
     }
 
-    func testEmptyDNAStringHasNoNucleotides() {
-        let dna = DNA(strand: "")!
+    func testEmptyDNAStringHasNoNucleotides() throws {
+        let dna = try XCTUnwrap(DNA(strand: ""), "Empty strands are valid strands and should not return nil")
         let results = dna.counts()
         let expected = ["T": 0, "A": 0, "C": 0, "G": 0]
         XCTAssertEqual(results, expected)
     }
 
-    func testRepetitiveCytidineGetsCounted() {
-        let dna = DNA(strand: "CCCCC")!
+    func testSingleNoNucleotideStrand() throws {
+        let dna = try XCTUnwrap(DNA(strand: "T"))
+        let results = dna.counts()
+        let expected = ["T": 1, "A": 0, "C": 0, "G": 0]
+        XCTAssertEqual(results, expected)
+    }
+
+    func testRepetitiveCytidineGetsCounted() throws {
+        let dna = try XCTUnwrap(DNA(strand: "CCCCC"))
         let result = dna.count("C")
         let expected = 5
         XCTAssertEqual(result, expected)
     }
 
-    func testRepetitiveSequenceHasOnlyGuanosine() {
-        let dna = DNA(strand: "GGGGGGGG")!
+    func testRepetitiveSequenceHasOnlyGuanosine() throws {
+        let dna = try XCTUnwrap(DNA(strand: "GGGGGGGG"))
         let results = dna.counts()
         let expected = [ "A": 0, "T": 0, "C": 0, "G": 8 ]
         XCTAssertEqual(results, expected)
     }
 
-    func testCountsByThymidine() {
-        let dna = DNA(strand: "GGGGGTAACCCGG")!
+    func testCountsByThymidine() throws {
+        let dna = try XCTUnwrap(DNA(strand: "GGGGGTAACCCGG"))
         let result = dna.count("T")
         let expected = 1
         XCTAssertEqual(result, expected)
     }
 
-    func testCountsANucleotideOnlyOnce() {
-        let dna = DNA(strand: "CGATTGGG")!
+    func testCountsANucleotideOnlyOnce() throws {
+        let dna = try XCTUnwrap(DNA(strand: "CGATTGGG"))
         let result = dna.count("T")
         let expected = 2
         XCTAssertEqual(result, expected)
     }
 
     func testValidatesDNA() {
-        XCTAssert(DNA(strand: "John") == nil )
+        XCTAssertNil(DNA(strand: "John"))
     }
 
-    func testCountsAllNucleotides() {
+    func testValidatesDNAWithValidPortion() {
+        XCTAssertNil(DNA(strand: "CATTAX"), "All characters in a strand need to be valid nucleotides.")
+    }
+
+
+    
+    func testCountsAllNucleotides() throws {
         let longStrand = "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"
-        let dna = DNA(strand: longStrand)!
+        let dna = try XCTUnwrap(DNA(strand: longStrand))
         let results = dna.counts()
         let expected = [ "A": 20, "T": 21, "C": 12, "G": 17 ]
         XCTAssertEqual(results, expected)
@@ -60,12 +73,14 @@ class NucleotideCountTests: XCTestCase {
         return [
             ("testEmptyDNAStringHasNoAdenosine", testEmptyDNAStringHasNoAdenosine),
             ("testEmptyDNAStringHasNoNucleotides", testEmptyDNAStringHasNoNucleotides),
+            ("testSingleNoNucleotideStrand", testSingleNoNucleotideStrand),
             ("testRepetitiveCytidineGetsCounted", testRepetitiveCytidineGetsCounted),
             ("testRepetitiveSequenceHasOnlyGuanosine", testRepetitiveSequenceHasOnlyGuanosine),
             ("testCountsByThymidine", testCountsByThymidine),
             ("testCountsANucleotideOnlyOnce", testCountsANucleotideOnlyOnce),
             ("testValidatesDNA", testValidatesDNA),
             ("testCountsAllNucleotides", testCountsAllNucleotides),
+            ("testValidatesDNAWithValidPortion", testValidatesDNAWithValidPortion),
         ]
     }
 }

--- a/exercises/nucleotide-count/Tests/NucleotideCountTests/NucleotideCountTests.swift
+++ b/exercises/nucleotide-count/Tests/NucleotideCountTests/NucleotideCountTests.swift
@@ -59,8 +59,6 @@ class NucleotideCountTests: XCTestCase {
         XCTAssertNil(DNA(strand: "CATTAX"), "All characters in a strand need to be valid nucleotides.")
     }
 
-
-    
     func testCountsAllNucleotides() throws {
         let longStrand = "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"
         let dna = try XCTUnwrap(DNA(strand: longStrand))


### PR DESCRIPTION
Added two tests that I have had students trip up on. Single nucleotide strands, and strands that contain both valid and invalid nucleotides (current validation test was only with all invalid characters).

More importantly, I modified the tests to remove force unwrapping and to use XCTUnwrap instead. We would encourage our students to not use force unwrapping in their code, and we shouldn't use it in ours.