### PR TITLE
Remove unintended whitespace in SaddlePointsTests.swift

### DIFF
--- a/exercises/saddle-points/Tests/SaddlePointsTests/SaddlePointsTests.swift
+++ b/exercises/saddle-points/Tests/SaddlePointsTests/SaddlePointsTests.swift
@@ -29,7 +29,7 @@ class SaddlePointsTests: XCTestCase {
     }
 
     func testExtractAColumn() {
-        let matrix = SaddlePointsMatrix("1 2 3\n4 5 6\n7 8 9\n 8 7 6")
+        let matrix = SaddlePointsMatrix("1 2 3\n4 5 6\n7 8 9\n8 7 6")
         XCTAssertEqual([1, 4, 7, 8], matrix.columns[0])
     }
 


### PR DESCRIPTION
The extra space was easy enough to parse out, but as a sole anomaly not alluded to in the README, it appeared unintentional. When it produced an error for me, the source wasn't readily apparent to me, so it's likely frustrated other learners too.