### PR TITLE
Fix fetching of latest release version in fetch-configlet

### DIFF
--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -26,7 +26,7 @@ case $(uname -m) in
         echo 64bit;;
 esac)
 
-VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
+VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/location:/{print $NF}' | tr -d '\r')"
 URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
 
 curl -s --location $URL | tar xz -C bin/

--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -26,7 +26,7 @@ case $(uname -m) in
         echo 64bit;;
 esac)
 
-VERSION="$(curl --head --location --silent $LATEST | awk -v FS=/ '/location:/{print $NF}' | tr -d '\r')"
+VERSION="$(curl --head --location --silent $LATEST | tr '[:upper:]' '[:lower:]' | awk -v FS=/ '/location:/{print $NF}' | tr -d '\r')"
 URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
 
 curl -s --location $URL | tar xz -C bin/

--- a/bin/fetch-configlet
+++ b/bin/fetch-configlet
@@ -26,7 +26,7 @@ case $(uname -m) in
         echo 64bit;;
 esac)
 
-VERSION="$(curl --head --silent $LATEST | awk -v FS=/ '/location:/{print $NF}' | tr -d '\r')"
+VERSION="$(curl --head --location --silent $LATEST | awk -v FS=/ '/location:/{print $NF}' | tr -d '\r')"
 URL=https://github.com/exercism/configlet/releases/download/$VERSION/configlet-$OS-${ARCH}.tgz
 
 curl -s --location $URL | tar xz -C bin/


### PR DESCRIPTION
Fixes CI builds. Issue seems to have been caused by a change in the GitHub API, according to [this PR in the go repo](https://github.com/exercism/go/pull/1343).