### PR TITLE
Fix broken image links in TESTS.md

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -6,7 +6,7 @@ This guide explains how to run unit tests for the Exercism Swift exercises using
 
 	1. `swift test` runs tests
 	2. `swift package generate-xcodeproj` creates an Xcode project
-	
+
 To run the tests from the command line, first `cd` to the exercise directory (for example, ~/exercism/swift/exercises/hello-world/), then execute `swift test`. This will compile the files in the Sources directory and execute the tests in the Tests directory. Alternatively, open the Xcode project and press Command-U.
 
 ### Overview
@@ -35,7 +35,7 @@ Optionally, Xcode can create a third file for experimentation:
 5. The items Package.swift, Configs, and Products are boilerplate that do not need modification.
 6. Congratulations! If the project builds successfully, configuration is complete.
 
-![file inspector](/docs/img/file-inspector.png)
+![file inspector](https://raw.githubusercontent.com/exercism/swift/master/docs/img/file-inspector.png)
 
 ### Xcode Playgrounds
 
@@ -52,11 +52,11 @@ Keep in mind that while playgrounds are useful for drafting code snippets and id
 
 Select the Tests Source file from the file inspector. You can trigger tests by clicking on one of the diamonds in the gutter of the file. The diamond next to the class definition will run all the tests, whereas the diamond next to each individual test will run only that test.
 
-![tests](/docs/img/tests.png)
+![tests](https://raw.githubusercontent.com/exercism/swift/master/docs/img/tests.png)
 
 Tests can also be invoked with Command-U, from the Test Inspector (Command-5), or from the sub-menu under the play button in the top bar. Red errors alongside all the tests are normal, since you have not witten any code yet!
 
-![failing tests](/docs/img/tests-fail.png)
+![failing tests](https://raw.githubusercontent.com/exercism/swift/master/docs/img/tests-fail.png)
 
 Test driven development is a very iterative process. The first step is to successfully run the tests and have them fail. Next try "sliming a test" by creating a method that returns a correct hard coded value for the first test. Sliming will confirm the project can compile and pass one test.
 
@@ -66,7 +66,7 @@ Remember that the exercise is solved with code in the application source file al
 
 Once all the tests are marked with a green icon, congratulations, you have successfully completed the exercise! Now submit it to the Exercism website for review. If you are impossibly stuck, submit the exercise before it is complete to view how other users solved the exercise.
 
-![passing tests](/docs/img/tests-pass.png)
+![passing tests](https://raw.githubusercontent.com/exercism/swift/master/docs/img/tests-pass.png)
 
 *The Hello-World exercise is a very simple coding problem, but the complexity of Xcode can make even simple exercises complex. We can ignore most of this complexity, because we only need to edit one file. You can always regenerate the Xcode project if something goes wrong.*
 


### PR DESCRIPTION
Fixes #373 
Tested locally in my browser. Should also work in production because the same fix (exercism/delphi#260) worked for the [Delphi track docs](https://exercism.io/tracks/delphi/installation).