### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "05a34b99-9343-4d2d-bd64-6f83bf13f23f",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Swift locally",
+      "blurb": "Learn how to install Swift locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "9f05410a-eb97-4268-be46-f4c0cd620610",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Swift",
+      "blurb": "An overview of how to get started from scratch with Swift"
+    },
+    {
+      "uuid": "7278a051-83c7-403c-b7ee-eec2d3909076",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Swift track",
+      "blurb": "Learn how to test your Swift exercises on Exercism"
+    },
+    {
+      "uuid": "1fd86dd4-97fa-430e-a208-89399c1a1601",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Swift resources",
+      "blurb": "A collection of useful resources to help you master Swift"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
