### PR TITLE
Enable concept exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
   "slug": "swift",
   "active": true,
   "status": {
-    "concept_exercises": false,
+    "concept_exercises": true,
     "test_runner": false,
     "representer": false,
     "analyzer": false


### PR DESCRIPTION
This PR enables the Concept Exercises for this track. Without setting this to `true`, they won't be available on the website.

Note that the Concept Exercises themselves also have to change their status from `wip` to `active` (or even better: just omit the `status` key) to enable them on the production website.

