### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/Sources/HelloWorld/HelloWorld.swift
+++ b/exercises/practice/hello-world/Sources/HelloWorld/HelloWorld.swift
@@ -1,1 +1,3 @@
-//Solution goes in Sources
+func hello() -> String {
+  return "Goodbye, Mars!"
+}

--- a/exercises/practice/hello-world/Sources/HelloWorld/HelloWorldExample.swift
+++ b/exercises/practice/hello-world/Sources/HelloWorld/HelloWorldExample.swift
@@ -1,9 +1,3 @@
-//
-// HelloWorld.swift
-//
-
-struct HelloWorld {
-    static func hello(_ text: String = "World") -> String {
-        return "Hello, \(text)!"
-    }
+func hello() -> String {
+  return "Hello, World!"
 }

--- a/exercises/practice/hello-world/Tests/HelloWorldTests/HelloWorldTests.swift
+++ b/exercises/practice/hello-world/Tests/HelloWorldTests/HelloWorldTests.swift
@@ -3,32 +3,13 @@ import XCTest
 
 class HelloWorldTests: XCTestCase {
 
-    func testNoName() {
-        let expected = "Hello, World!"
-        XCTAssertEqual(HelloWorld.hello(), expected, "When given no name, we should greet the world!")
-    }
-
-    func testSampleName() {
-        let expected = "Hello, Alice!"
-        XCTAssertEqual(HelloWorld.hello("Alice"), expected, "When given 'Alice' we should greet Alice!")
-    }
-
-    func testOtherSampleName() {
-        let expected = "Hello, Bob!"
-        XCTAssertEqual(HelloWorld.hello("Bob"), expected, "When given 'Bob' we should greet Bob!")
-    }
-
-    func testNoStrangeName() {
-        let expected = "Hello, !"
-        XCTAssertEqual(HelloWorld.hello(""), expected, "When given an empty string, it is strange, but should have a space and punctuation")
+    func testHello() {
+        XCTAssertEqual(hello(), "Hello, World!")
     }
 
     static var allTests: [(String, (HelloWorldTests) -> () throws -> Void)] {
         return [
-            ("testNoName", testNoName),
-            ("testSampleName", testSampleName),
-            ("testOtherSampleName", testOtherSampleName),
-            ("testNoStrangeName", testNoStrangeName),
+            ("testHello", testHello),
         ]
     }
 }


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46
