### PR TITLE
Fix prerequisites of concept exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -143,7 +143,7 @@
         "name": "Santa's Swifty Helper",
         "uuid": "f371c072-082b-496b-aa58-45b6cba203f6",
         "concepts": ["tuples"],
-        "prerequisites": ["arrays", "strings"],
+        "prerequisites": ["arrays", "characters"],
         "status": "active"
       },
       {

--- a/config.json
+++ b/config.json
@@ -89,7 +89,7 @@
           "inout-parameters",
           "nested-functions"
         ],
-        "prerequisites": ["arrays", "conditionals", "tuples"],
+        "prerequisites": ["arrays", "conditionals-if", "conditionals-guard", "conditionals-switch", "tuples"],
         "status": "active"
       },
       {
@@ -119,7 +119,7 @@
         "name": "Magician-in-Training",
         "uuid": "e6143dbc-895e-47aa-b42c-3034e1f872c2",
         "concepts": ["arrays"],
-        "prerequisites": ["conditionals"],
+        "prerequisites": ["conditionals-if", "conditionals-guard", "conditionals-switch"],
         "status": "active"
       },
       {
@@ -127,7 +127,7 @@
         "name": "Slice Sizing",
         "uuid": "9d0bb0ad-904c-4d61-9d2c-ae37913d5741",
         "concepts": ["optionals"],
-        "prerequisites": ["tuples", "conditionals"],
+        "prerequisites": ["tuples", "conditionals-if", "conditionals-guard", "conditionals-switch"],
         "status": "active"
       },
       {

--- a/exercises/concept/santas-helper/.meta/design.md
+++ b/exercises/concept/santas-helper/.meta/design.md
@@ -20,5 +20,5 @@ This concept exercise should convey a basic understanding of how to work with tu
 ## Prerequisites
 
 - `basics`: : know what a value is; know how to define a constant; know how to define a variable; know how to define a function
-- `strings-and-characters`: Know what a string is
+- `characters`: Know what a string is
 - `arrays`: know what an array is


### PR DESCRIPTION
This fixes some prerequisites of concept exercises that point to concepts that do not exist (yet). Specifically, the following non-existing concepts were prerequisites for other exercises:

- `strings` (should probably be `characters` instead)
- `conditionals` (covered by `conditionals-if`, `conditionals-guard` and `conditionals-switch`)

Because of these incorrect prerequisites some exercises remain locked without a way to unlock them.

Note: An alternative fix for `conditionals` could be to add the `conditionals` concept to the appropriate exercises instead of changing the prerequisites of the others.