### PR TITLE
#485: FreelancerRates tests makeover

### DIFF
--- a/exercises/concept/freelancer-rates/Tests/FreelancerRatesTests/FreelancerRatesTests.swift
+++ b/exercises/concept/freelancer-rates/Tests/FreelancerRatesTests/FreelancerRatesTests.swift
@@ -2,40 +2,138 @@ import XCTest
 
 @testable import FreelancerRates
 
+/// Tests the correctness of `FreelancerRates` functions outcomes
 final class FreelancerRatesTests: XCTestCase {
-  let runAll = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"]) ?? false
 
-  func testdailyRateFrom() {
-    XCTAssertEqual(dailyRateFrom(hourlyRate: 60), 480.0, accuracy: 0.001)
-  }
+    // MARK: - Instance Properties
 
-  func testmonthlyRoundDown() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    XCTAssertEqual(monthlyRateFrom(hourlyRate: 77, withDiscount: 10.5), 12129, accuracy: 0.001)
-  }
+    /// Triggers the `passthrough` testing pipe
+    private let runAll = Bool(
+        ProcessInfo.processInfo.environment["RUNALL", default: "false"]
+    ) ?? false
 
-  func testmonthlyRoundUp() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    XCTAssertEqual(monthlyRateFrom(hourlyRate: 80, withDiscount: 10.5), 12602, accuracy: 0.001)
-  }
+    /// Calculations accuracy threshold
+    /// - Note: This can be potentially discussible as no strict rules defined for the rounding
+    private let accuracy = 0.001
 
-  func testworkdaysIn() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    XCTAssertEqual(
-      workdaysIn(budget: 20_000, hourlyRate: 80, withDiscount: 11), 35.0, accuracy: 0.001)
-  }
+    // MARK: - Tests
 
-  func testworkdaysShouldRoundDown() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    XCTAssertEqual(
-      workdaysIn(budget: 25_000, hourlyRate: 80, withDiscount: 11), 43, accuracy: 0.001)
-  }
+    /// Tests that user `dailyRateFrom(hourlyRate:)` imp produces expected outcome
+    func testdailyRateFrom() {
 
-  static var allTests = [
-    ("testdailyRateFrom", testdailyRateFrom),
-    ("testmonthlyRoundDown", testmonthlyRoundDown),
-    ("testmonthlyRoundUp", testmonthlyRoundUp),
-    ("testworkdaysIn", testworkdaysIn),
-    ("testworkdaysShouldRoundDown", testworkdaysShouldRoundDown),
-  ]
+        // Arrange
+        let userResult = dailyRateFrom(hourlyRate: 60)
+        let expectedResult: Double = 480
+
+        // Assert
+        XCTAssertEqual(
+            userResult,
+            expectedResult,
+            accuracy: 0.001,
+            "Your dailyRate func returned \(userResult), while \(480) was expected"
+        )
+    }
+
+    /// Tests that user `monthlyRateFrom(hourlyRate:,discount:)` imp produces expected outcome
+    func testmonthlyRoundDown() throws {
+
+        // Arrange
+        let userResult = monthlyRateFrom(
+            hourlyRate: 77,
+            withDiscount: 10.5
+        )
+        let expectedResult: Double = 12129
+
+        // Act
+        /// Change `true` to `false` to run this test
+        try XCTSkipIf(false && !runAll)
+
+        // Assert
+        XCTAssertEqual(
+            userResult,
+            expectedResult,
+            accuracy: 0.001,
+            "Your monthly func returned \(userResult), while \(expectedResult) was expected"
+        )
+    }
+
+    /// Tests that user `monthlyRateFrom(hourlyRate:discount:)` imp rounds correctly
+    ///  - Note: Do we really need so precise accuracy, maybe we can hust match vs. `Int`?
+    func testmonthlyRoundUp() throws {
+
+        // Arrange
+        let userResult = monthlyRateFrom(
+            hourlyRate: 80,
+            withDiscount: 10.5
+        )
+        let expectedResult: Double = 12602
+
+        // Act
+        /// Change `true` to `false` to run this test
+        try XCTSkipIf(false && !runAll)
+
+        // Assert
+        XCTAssertEqual(
+            userResult,
+            expectedResult,
+            accuracy: 0.001,
+            "Your monthly func returned \(userResult), while \(expectedResult) was expected"
+        )
+    }
+
+    /// Tests that user `workdaysIn(budget:hourlyRate:discount:)` imp produces expected outcome
+    func testworkdaysIn() throws {
+
+        // Arrange
+        let userResult = workdaysIn(
+            budget: 20_000,
+            hourlyRate: 80,
+            withDiscount: 11
+        )
+        let expectedResult: Double = 35
+
+        // Act
+        /// Change `true` to `false` to run this test
+        try XCTSkipIf(false && !runAll)
+
+        // Assert
+        XCTAssertEqual(
+            userResult,
+            expectedResult,
+            accuracy: 0.001,
+            "Your workday func returned \(userResult), while \(expectedResult) was expected"
+        )
+    }
+
+    /// Tests that user `workdaysIn(budget:hourlyRate:discount:)` imp rounds correctly
+    func testworkdaysShouldRoundDown() throws {
+
+        // Arrange
+        let userResult = workdaysIn(
+            budget: 25_000,
+            hourlyRate: 80,
+            withDiscount: 11
+        )
+        let expectedResult: Double = 43
+
+        // Act
+        /// Change `true` to `false` to run this test
+        try XCTSkipIf(false && !runAll)
+
+        // Assert
+        XCTAssertEqual(
+            userResult,
+            expectedResult,
+            accuracy: 0.001,
+            "Your workday func returned \(userResult), while \(expectedResult) was expected"
+        )
+    }
+
+    static var allTests = [
+        ("testdailyRateFrom", testdailyRateFrom),
+        ("testmonthlyRoundDown", testmonthlyRoundDown),
+        ("testmonthlyRoundUp", testmonthlyRoundUp),
+        ("testworkdaysIn", testworkdaysIn),
+        ("testworkdaysShouldRoundDown", testworkdaysShouldRoundDown)
+    ]
 }


### PR DESCRIPTION
Hello dear Exercism team! Recently I stumbled upon a strange issue: when test of [FreelancerRates](https://exercism.org/tracks/swift/exercises/freelancer-rates/edit) exercises are run, no communication is provided on failure, please see the [screenshot](https://imgur.com/a/zI0i9lm).
IMHO this can be due to lack of XCAssert messages (Xcode errors may not be communicated to web frontend, dunno). So I slightly rewritten the tests and made them more well-looking and documented, please have a look!

Do not hesitate to write if you have any questions!