### PR TITLE
Fix description of totalTimeInMinutes method for lasagna task

### DIFF
--- a/exercises/concept/lasagna/.docs/instructions.md
+++ b/exercises/concept/lasagna/.docs/instructions.md
@@ -33,7 +33,7 @@ preparationTimeInMinutes(layers: 2)
 
 ## 4. Calculate the total working time in minutes
 
-Define the `totalTimeInMinutes` function that takes two parameters: the first parameter is the number of layers you added to the lasagna, and the second parameter is the number of minutes the lasagna has been in the oven. The function should return how many minutes in total you've worked on cooking the lasagna, which is the sum of the preparation time in minutes, and the time in minutes the lasagna has spent in the oven at the moment.
+Define the `totalTimeInMinutes` function that takes two parameters: the first parameter is the number of layers you added to the lasagna, and the second parameter is the number of minutes the lasagna has been in the oven. The function should return how many minutes in total you've worked on cooking the lasagna, which is the sum of the preparation time in minutes, and remaining minutes in oven.
 
 ```swift
 totalTimeInMinutes(layers: 3, elapsedMinutes: 20)


### PR DESCRIPTION
Changed description of lasagna task for test compliance.

In the task, we expect that in the `totalTimeInMinutes` method we will use the code of the previously implemented methods` remainingMinutesInOven` and` preparationTimeInMinutes`