### PR TITLE
Log Lines : fix LogLine by LogLevel in instructions

### DIFF
--- a/exercises/concept/log-lines/.docs/instructions.md
+++ b/exercises/concept/log-lines/.docs/instructions.md
@@ -29,12 +29,12 @@ Define a `LogLevel` enum that has six cases corresponding to the above log level
 
 ## 2. Parse log level
 
-Next, implement the `LogLine` initializer to parse the log level of a log line:
+Next, implement the `LogLevel` initializer to parse the log level of a log line:
 
 ```swift
-LogLine("[INF]: File deleted")
+LogLevel("[INF]: File deleted")
 // => LogLevel.info
-LogLine("Something went wrong!")
+LogLevel("Something went wrong!")
 // => LogLevel.unknown
 ```
 


### PR DESCRIPTION
Point 2 mentions `LogLine` but it should be `LogLevel`.

> Next, implement the LogLevel initializer to parse the log level of a log line:
> 
> ```
> LogLevel("[INF]: File deleted")
> // => LogLevel.info
> LogLevel("Something went wrong!")
> // => LogLevel.unknown
> ```