### PR TITLE
fix miss typo on instructions.md and introduction.md

### DIFF
--- a/exercises/concept/freelancer-rates/.docs/instructions.md
+++ b/exercises/concept/freelancer-rates/.docs/instructions.md
@@ -28,7 +28,7 @@ Implement the function `monthlyRateFrom(hourlyRate:withDiscount:)` to calculate 
 
 ```swift
 monthlyRateFrom(hourlyRate: 77, withDiscount: 10.5)
-# => 12130
+# => 12129
 ```
 
 The returned monthly rate should be returned as a Double rounded to the nearest integer.

--- a/exercises/concept/freelancer-rates/.docs/introduction.md
+++ b/exercises/concept/freelancer-rates/.docs/introduction.md
@@ -24,7 +24,7 @@ let z: Double = 42 // z is a Double
 
 In Swift, assignment of a value between different types requires explicit conversion. For example, to convert an `Int` to a `Double` and vice versa, you would need to do the following:
 
-````swift
+```swift
 let x = 42
 let d = Double(x)
 
@@ -41,5 +41,5 @@ print("pi:", pi, "is of type:", type(of: pi))
 // Output: pi: 3.141592653589793 is of type: Double
 
 print("iPi:", iPi, "is of type:", type(of: iPi))
-// Output: iPi: 3 is of type: Int```
-````
+// Output: iPi: 3 is of type: Int
+```

--- a/exercises/concept/vehicle-purchase/.docs/introduction.md
+++ b/exercises/concept/vehicle-purchase/.docs/introduction.md
@@ -84,7 +84,7 @@ guard myValue = 0 else { return 0 }
 let root = myValue.squareRoot()
 ```
 
-Here, the `guard` checks if the Boolean expression following the `guard` keyword evaluates as true. If it does, then processing continues with the code following the guard statement (here `let root = myValue.squareRoot()`. Otherwise it will execute the code in the else clause. Unlike an `if` statement, a `guard` statement _must_ have an else clause, and unlike the else clause of an if-else, the else clause of a guard _must_ exit the scope of the guard statement. I.e. it must use a control transfer statement such as return, continue, break, or it must throw an error or exit the program.
+Here, the `guard` checks if the Boolean expression following the `guard` keyword evaluates as true. If it does, then processing continues with the code following the guard statement (here `let root = myValue.squareRoot()`). Otherwise it will execute the code in the else clause. Unlike an `if` statement, a `guard` statement _must_ have an else clause, and unlike the else clause of an if-else, the else clause of a guard _must_ exit the scope of the guard statement. I.e. it must use a control transfer statement such as return, continue, break, or it must throw an error or exit the program.
 
 An example of its use is the sinc function, which is equal to sin(x)/x with sinc(0) defined to be 1, avoiding issues with division by 0. This function can be written in Swift, using a `guard` as:
 


### PR DESCRIPTION
I found some typo issue during solving the exercise.
It would be nice to merge this PR for someone would get confused when they see it.
