### PR TITLE
lasagna-master: Update tests of final task to match instructions

### DIFF
--- a/exercises/concept/lasagna-master/.meta/Sources/LasagnaMaster/LasagnaMasterExemplar.swift
+++ b/exercises/concept/lasagna-master/.meta/Sources/LasagnaMaster/LasagnaMasterExemplar.swift
@@ -60,6 +60,6 @@ func redWine(layers: String...) -> Bool {
     return count
   }
 
-  return countMozzarella() + countRicotta() + countBechamel() < countMeat() + countSauce()
+  return countMozzarella() + countRicotta() + countBechamel() <= countMeat() + countSauce()
 
 }

--- a/exercises/concept/lasagna-master/Tests/LasagnaMasterTests/LasagnaMasterTests.swift
+++ b/exercises/concept/lasagna-master/Tests/LasagnaMasterTests/LasagnaMasterTests.swift
@@ -71,7 +71,7 @@ final class LasagnaMasterTests: XCTestCase {
     XCTAssertFalse(
       redWine(
         layers: "sauce", "noodles", "béchamel", "meat", "mozzarella", "noodles", "sauce", "ricotta",
-        "eggplant", "béchamel", "noodles", "meat", "sauce", "mozzarella"))
+        "eggplant", "mozzarella", "béchamel", "noodles", "meat", "sauce", "mozzarella"))
   }
 
   static var allTests = [

--- a/exercises/concept/lasagna-master/Tests/LasagnaMasterTests/LasagnaMasterTests.swift
+++ b/exercises/concept/lasagna-master/Tests/LasagnaMasterTests/LasagnaMasterTests.swift
@@ -60,10 +60,18 @@ final class LasagnaMasterTests: XCTestCase {
     XCTAssertEqual(amount.sauce, 20.2884, accuracy: 0.001)
   }
 
-  func testRedWineRed() throws {
+  func testRedWineRedInequalLayerCount() throws {
     try XCTSkipIf(true && !runAll)  // change true to false to run this test
     XCTAssertTrue(
       redWine(layers: "sauce", "noodles", "sauce", "noodles", "meat", "noodles", "mozzarella"))
+  }
+  
+  func testRedWineRedEqualLayerCount() throws {
+    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+    XCTAssertTrue(
+      redWine(
+        layers: "sauce", "noodles", "ricotta", "sauce", "noodles", "béchamel", "meat", "noodles", 
+        "mozzarella"))
   }
 
   func testRedWineWhite() throws {
@@ -83,7 +91,8 @@ final class LasagnaMasterTests: XCTestCase {
     ("testQuantitiesNoSauce", testQuantitiesNoSauce),
     ("testQuantitiesNoNoodles", testQuantitiesNoNoodles),
     ("testToOz", testToOz),
-    ("testRedWineRed", testRedWineRed),
+    ("testRedWineRedInequalLayerCount", testRedWineRedInequalLayerCount),
+    ("testRedWineRedEqualLayerCount", testRedWineRedEqualLayerCount),
     ("testRedWineWhite", testRedWineWhite),
   ]
 }


### PR DESCRIPTION
From the instructions:

> You've heard that you should serve white wine if there is more mozzarella, ricotta, and béchamel in the lasagna than there is meat and sauce, and red wine otherwise.

Let's call the number of mozzarella/ricotta/béchamel layers `A` and the number of meat/sauce layers `B`: according to the instructions white wine should be served when `A > B`, which means that the `redWine` function should return `true` when `A <= B`, not `A < B`. 

However, in the test case `A == B`, which means that the test fails if a student implements the `redWine` function to return `true` when `A <= B`. To fix this, I added an extra `"mozzarella"` layer to the test case, so that it represents the case `A > B` and therefore correctly expects `false`.