### PR TITLE
Fix layers-of-lasagna test error (missing parens in test file)

### DIFF
--- a/exercises/concept/lasagna/Tests/LasagnaTests/LasagnaTests.swift
+++ b/exercises/concept/lasagna/Tests/LasagnaTests/LasagnaTests.swift
@@ -5,7 +5,7 @@ final class LasagnaTests: XCTestCase {
   let runAll = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"]) ?? false
 
   func testExpectedMinutes() {
-    XCTAssertEqual(expectedMinutesInOven, 40)
+    XCTAssertEqual(expectedMinutesInOven(), 40)
   }
 
   func testRemainingMinutes() throws {


### PR DESCRIPTION
Hi,

My lasagna fell apart, but with this fix the lasagna test will run again locally but also on exercism.

My local swift version is 5.5.1-dev (macOS 12.0.1), but it also fails on exercism. (oh, removed url since my failed run can't be published) 

Error:

```
<path>/exercism/swift/lasagna/Tests/LasagnaTests/LasagnaTests.swift:8:20: error: add () to forward @autoclosure parameter
    XCTAssertEqual(expectedMinutesInOven, 40) // !!
                   ^~~~~~~~~~~~~~~~~~~~~
                                        ()
[1/2] Compiling LasagnaTests LasagnaTests.swift
error: fatalError
```

Disclaimer: I'm totally new to Swift, but ... I think this should be alright :)