### PR TITLE
Changed expected value for 'testForcefulQuestions' unit test

### DIFF
--- a/exercises/practice/bob/Tests/BobTests/BobTests.swift
+++ b/exercises/practice/bob/Tests/BobTests/BobTests.swift
@@ -40,7 +40,7 @@ class BobTests: XCTestCase {
 
     func testForcefulQuestions() {
         let input = "WHAT THE HELL WERE YOU THINKING?"
-        let expected = "Whoa, chill out!"
+        let expected = "Calm down, I know what I'm doing!"
         let result = Bob.hey(input)
         XCTAssertEqual(expected, result)
     }


### PR DESCRIPTION
The input: "WHAT THE HELL WERE YOU THINKING?"

It's a question that is in all caps, so, it meets the criteria for yelling a question.

Current expected value does not match what should be returned when a question is yelled.