### PR TITLE
Fix typos in instructions.md and introduction.md

### DIFF
--- a/exercises/concept/vehicle-purchase/.docs/instructions.md
+++ b/exercises/concept/vehicle-purchase/.docs/instructions.md
@@ -28,7 +28,7 @@ licenseType(numberOfWheels: 6)
 // => "You will need an automobile license for your vehicle"
 licenseType(numberOfWheels: 18)
 // => "You will need a commercial trucking license for your vehicle"
-licenceType(numberOfWheels: 0)
+licenseType(numberOfWheels: 0)
 // => "We do not issue licenses for those types of vehicles"
 ```
 

--- a/exercises/concept/vehicle-purchase/.docs/introduction.md
+++ b/exercises/concept/vehicle-purchase/.docs/introduction.md
@@ -84,7 +84,7 @@ guard myValue = 0 else { return 0 }
 let root = myValue.squareRoot()
 ```
 
-Here, the `guard` checks if the Boolean expression following the `guard` keyword evaluates as true. If it does, then processing continues with the code following the guard statement (here `let root = myValue.squareRoot()`. Otherwise it will execute the code in the else clause. Unlike an `if` statement, a `guard` statement _must_ have an else clause, and unlike the else clause of an if-else, the else clause of a guard _must_ exit the scope of the guard statement. I.e. it must use a control transfer statement she as return, continue, break, or it must throw an error or exit the program.
+Here, the `guard` checks if the Boolean expression following the `guard` keyword evaluates as true. If it does, then processing continues with the code following the guard statement (here `let root = myValue.squareRoot()`. Otherwise it will execute the code in the else clause. Unlike an `if` statement, a `guard` statement _must_ have an else clause, and unlike the else clause of an if-else, the else clause of a guard _must_ exit the scope of the guard statement. I.e. it must use a control transfer statement such as return, continue, break, or it must throw an error or exit the program.
 
 An example of its use is the sinc function, which is equal to sin(x)/x with sinc(0) defined to be 1, avoiding issues with division by 0. This function can be written in Swift, using a `guard` as:
 


### PR DESCRIPTION
Proposed fixes for:
`licence` to `license` in
```licenceType(numberOfWheels: 0)```

`she` to `such` in
I.e. it must use a control transfer statement she as return, continue, break, or it must throw an error or exit the program.