### PR TITLE
Magician-in-Training: Fix typos in instructions.md and introduction.md

### DIFF
--- a/exercises/concept/magician-in-training/.docs/instructions.md
+++ b/exercises/concept/magician-in-training/.docs/instructions.md
@@ -89,5 +89,5 @@ Implement the function `evenCardCount(_:)` that steps through the stack and coun
 
 ```swift
 evenCardCount([3,8,4,5,1,6,10])
-// => 3
+// => 4
 ```

--- a/exercises/concept/magician-in-training/.docs/introduction.md
+++ b/exercises/concept/magician-in-training/.docs/introduction.md
@@ -13,7 +13,7 @@ var myStringArray: [String] = []
 
 Elements of an array can be accessed individually by supplying the index of the element inside square brackets following the array; array indices are `Int`s and start with `0` for the first (leftmost) element. This subscript notation can be used to get the element at that index as well as to set the element at that index, provided the array was defined as a variable (i.e. using `var`).
 
-Trying to access elements at indices outside the valid range of indices will result in a runtime error that crashes the program. Since any invalid array index access will crash a program, it is common to test arrays to see if the are empty before working with them by checking the `isEmpty` property or checking if an index is valid by ensuring that it is greater than or equal to 0 and less than the array's `count` property.
+Trying to access elements at indices outside the valid range of indices will result in a runtime error that crashes the program. Since any invalid array index access will crash a program, it is common to test arrays to see if they are empty before working with them by checking the `isEmpty` property or checking if an index is valid by ensuring that it is greater than or equal to 0 and less than the array's `count` property.
 
 ```swift
 evenInts[2]


### PR DESCRIPTION
Proposed fixes for:
`the` to `they` in
"arrays to see if the are empty before"

`3` to `4`
evenCardCount([3,8,4,5,1,6,10]) // There are 4 even numbers (not 3)
// => 3  <--- Here