### PR TITLE
Fix ci linter issue for missing slug

### DIFF
--- a/config.json
+++ b/config.json
@@ -1054,6 +1054,11 @@
       "name": "Constants"
     },
     {
+      "uuid": "5085d8c0-fa12-44d1-a781-b80d1f8ec9e6",
+      "slug": "constants-and-variables",
+      "name": "Constants And Variables"
+    },
+    {
       "uuid": "5ab7940e-0eea-435c-b3ac-dc3f77f536cf",
       "slug": "control-transfer",
       "name": "Contro transfer"


### PR DESCRIPTION
This resolves the following issue:

```
`/home/runner/work/swift/swift/concepts` contains a directory named `constants-and-variables`, which is not a `slug` in the concepts array. Please add the concept to that array:
/home/runner/work/swift/swift/config.json
```

Can be seen here: https://github.com/exercism/swift/runs/4304703883?check_suite_focus=true

This may also relate to issue: https://github.com/exercism/swift/issues/476