### PR TITLE
Fixed typo in dict2 declaration

### DIFF
--- a/concepts/dictionaries/introduction.md
+++ b/concepts/dictionaries/introduction.md
@@ -9,7 +9,7 @@ var addresses: Dictionary<String, String> = ["The Munsters": "1313 Mockingbird L
 var sequences: [String: [Int]] = ["Euler's totient": [1, 1, 2, 2, 4, 2, 6, 4], "Lazy caterer": [1, 2, 4, 7, 11, 16, 22, 29, 37], "Carmichael": [561, 1105, 1729, 2465, 2821, 6601, 8911, 10585, 15841]]
 let constants = ["pi": 3.14159, "e": 2.71828, "phi": 1.618033, "avogadro": 6.02214076e22]
 var emptyDict1: [Int: Int] = [:]
-var emptyDict2 = ["Character": "String"]()
+var emptyDict2 = [Character: String]()
 var emptyDict3 = Dictionary<Int, Double>()
 ```
 


### PR DESCRIPTION
```swift
var emptyDict2 = ["Character": "String"]()
```

This declaration will not compile as there is key and value provided, not the types of the Dictionary.

<img width="812" alt="Screenshot 2022-04-02 at 16 26 47" src="https://user-images.githubusercontent.com/73189234/161383240-562d338b-275b-455d-bd8f-424f36492293.png">

The correct form should look like this:

<img width="394" alt="Screenshot 2022-04-02 at 16 27 59" src="https://user-images.githubusercontent.com/73189234/161383299-18d7a255-dc9d-4da4-add1-7c9d7e083bb3.png">

