### PR TITLE
Explicit expectations

### DIFF
--- a/exercises/practice/gigasecond/Sources/Gigasecond/Gigasecond.swift
+++ b/exercises/practice/gigasecond/Sources/Gigasecond/Gigasecond.swift
@@ -1,1 +1,2 @@
-//Solution goes in Sources
+// Define "Gigasecond" with a "description" property containing
+// the result, times are expected in "yyyy-MM-dd'T'HH:mm:ss" format


### PR DESCRIPTION
This will help to avoid needing to inspect the tests in order to understand the expected names and structures. It should be edited by a maintainer to better fit if needed.