### PR TITLE
Fix expected value for testTotalMinutes

### DIFF
--- a/exercises/concept/lasagna/Tests/LasagnaTests/LasagnaTests.swift
+++ b/exercises/concept/lasagna/Tests/LasagnaTests/LasagnaTests.swift
@@ -20,7 +20,7 @@ final class LasagnaTests: XCTestCase {
 
   func testTotalMinutes() throws {
     try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    XCTAssertEqual(totalTimeInMinutes(layers: 6, elapsedMinutes: 13), 25)
+    XCTAssertEqual(totalTimeInMinutes(layers: 6, elapsedMinutes: 13), 39)
   }
 
   static var allTests = [


### PR DESCRIPTION
Following the description, it should be testRemainingMinutes(elapsedMinutes: 13) + testPreparationMinutes(layers: 6) which return 27 and 12 and the total is 39, not 25