### PR TITLE
Revert "Update testSetCard in MagicianInTraining Unit Test"

### DIFF
--- a/exercises/concept/magician-in-training/Tests/MagicianInTrainingTests/MagicianInTrainingTests.swift
+++ b/exercises/concept/magician-in-training/Tests/MagicianInTrainingTests/MagicianInTrainingTests.swift
@@ -13,79 +13,79 @@ final class MagicianInTrainingTests: XCTestCase {
 
   func testSetCard() throws {
     try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    var stack = [9, 4, 3, 6, 1, 7, 2, 8, 5]
+    let stack = [9, 4, 3, 6, 1, 7, 2, 8, 5]
     let idx = 5
     XCTAssertEqual(setCard(at: idx, in: stack, to: 10), [9, 4, 3, 6, 1, 10, 2, 8, 5])
   }
 
   func testSetCardIndexTooLow() throws {
     try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    var stack = [9, 4, 3, 6, 1, 7, 2, 8, 5]
+    let stack = [9, 4, 3, 6, 1, 7, 2, 8, 5]
     let idx = -3
     XCTAssertEqual(setCard(at: idx, in: stack, to: 10), stack)
   }
 
   func testSetCardIndexTooHigh() throws {
     try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    var stack = [9, 4, 3, 6, 1, 7, 2, 8, 5]
+    let stack = [9, 4, 3, 6, 1, 7, 2, 8, 5]
     let idx = 50
     XCTAssertEqual(setCard(at: idx, in: stack, to: 10), stack)
   }
 
   func testInsertAtTop() throws {
     try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    var stack = [1, 7, 5, 8, 3, 9, 6, 4, 2]
+    let stack = [1, 7, 5, 8, 3, 9, 6, 4, 2]
     XCTAssertEqual(insert(10, atTopOf: stack), [1, 7, 5, 8, 3, 9, 6, 4, 2, 10])
   }
 
   func testRemoveCard() throws {
     try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    var stack = [9, 2, 1, 6, 5, 7, 4, 3, 8]
+    let stack = [9, 2, 1, 6, 5, 7, 4, 3, 8]
     let idx = 2
     XCTAssertEqual(removeCard(at: idx, from: stack), [9, 2, 6, 5, 7, 4, 3, 8])
   }
 
   func testRemoveCardIndexTooLow() throws {
     try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    var stack = [9, 2, 1, 6, 5, 7, 4, 3, 8]
+    let stack = [9, 2, 1, 6, 5, 7, 4, 3, 8]
     let idx = -2
     XCTAssertEqual(removeCard(at: idx, from: stack), stack)
   }
 
   func testRemoveCardIndexTooHigh() throws {
     try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    var stack = [9, 2, 1, 6, 5, 7, 4, 3, 8]
+    let stack = [9, 2, 1, 6, 5, 7, 4, 3, 8]
     let idx = 20
     XCTAssertEqual(removeCard(at: idx, from: stack), stack)
   }
 
   func testRemoveTopCard() throws {
     try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    var stack = [2, 7, 4, 6, 9, 1, 8, 3, 5]
+    let stack = [2, 7, 4, 6, 9, 1, 8, 3, 5]
     XCTAssertEqual(removeTopCard(stack), [2, 7, 4, 6, 9, 1, 8, 3])
   }
 
   func testRemoveTopCardFromEmptyStack() throws {
     try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    var stack = [Int]()
+    let stack = [Int]()
     XCTAssertEqual(removeTopCard(stack), stack)
   }
 
   func testInsertAtBottom() throws {
     try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    var stack = [4, 3, 8, 9, 1, 7, 6, 5, 2]
+    let stack = [4, 3, 8, 9, 1, 7, 6, 5, 2]
     XCTAssertEqual(insert(10, atBottomOf: stack), [10, 4, 3, 8, 9, 1, 7, 6, 5, 2])
   }
 
   func testRemoveBottomCard() throws {
     try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    var stack = [8, 7, 4, 2, 6, 5, 3, 1, 9]
+    let stack = [8, 7, 4, 2, 6, 5, 3, 1, 9]
     XCTAssertEqual(removeBottomCard(stack), [7, 4, 2, 6, 5, 3, 1, 9])
   }
 
   func testRemoveBottomCardFromEmptyStack() throws {
     try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    var stack = [Int]()
+    let stack = [Int]()
     XCTAssertEqual(removeTopCard(stack), stack)
   }
 
@@ -97,7 +97,7 @@ final class MagicianInTrainingTests: XCTestCase {
 
   func testCheckSizeFalse() throws {
     try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    var stack = [6, 9, 7, 8, 2, 3, 4, 5, 1]
+    let stack = [6, 9, 7, 8, 2, 3, 4, 5, 1]
     XCTAssertFalse(checkSizeOfStack(removeBottomCard(stack), 9))
   }
 


### PR DESCRIPTION
Reverts exercism/swift#559
I'm sorry, I think I've made a mistake that appeared in the test from my last PR
As I didn't think about returning new arrays, as the parameter of a function is a constant...
Can you please revert the changes?

```
/mnt/exercism-iteration/Tests/MagicianInTrainingTests/MagicianInTrainingTests.swift:16:9: warning: variable 'stack' was never mutated; consider changing to 'let' constant
    var stack = [9, 4, 3, 6, 1, 7, 2, 8, 5]
    ~~~ ^
    let
/mnt/exercism-iteration/Tests/MagicianInTrainingTests/MagicianInTrainingTests.swift:23:9: warning: variable 'stack' was never mutated; consider changing to 'let' constant
    var stack = [9, 4, 3, 6, 1, 7, 2, 8, 5]
    ~~~ ^
    let
/mnt/exercism-iteration/Tests/MagicianInTrainingTests/MagicianInTrainingTests.swift:30:9: warning: variable 'stack' was never mutated; consider changing to 'let' constant
    var stack = [9, 4, 3, 6, 1, 7, 2, 8, 5]
    ~~~ ^
    let
/mnt/exercism-iteration/Tests/MagicianInTrainingTests/MagicianInTrainingTests.swift:37:9: warning: variable 'stack' was never mutated; consider changing to 'let' constant
    var stack = [1, 7, 5, 8, 3, 9, 6, 4, 2]
    ~~~ ^
    let
/mnt/exercism-iteration/Tests/MagicianInTrainingTests/MagicianInTrainingTests.swift:43:9: warning: variable 'stack' was never mutated; consider changing to 'let' constant
    var stack = [9, 2, 1, 6, 5, 7, 4, 3, 8]
    ~~~ ^
    let
/mnt/exercism-iteration/Tests/MagicianInTrainingTests/MagicianInTrainingTests.swift:50:9: warning: variable 'stack' was never mutated; consider changing to 'let' constant
    var stack = [9, 2, 1, 6, 5, 7, 4, 3, 8]
    ~~~ ^
    let
/mnt/exercism-iteration/Tests/MagicianInTrainingTests/MagicianInTrainingTests.swift:57:9: warning: variable 'stack' was never mutated; consider changing to 'let' constant
    var stack = [9, 2, 1, 6, 5, 7, 4, 3, 8]
    ~~~ ^
    let
/mnt/exercism-iteration/Tests/MagicianInTrainingTests/MagicianInTrainingTests.swift:64:9: warning: variable 'stack' was never mutated; consider changing to 'let' constant
    var stack = [2, 7, 4, 6, 9, 1, 8, 3, 5]
    ~~~ ^
    let
/mnt/exercism-iteration/Tests/MagicianInTrainingTests/MagicianInTrainingTests.swift:70:9: warning: variable 'stack' was never mutated; consider changing to 'let' constant
    var stack = [Int]()
    ~~~ ^
    let
/mnt/exercism-iteration/Tests/MagicianInTrainingTests/MagicianInTrainingTests.swift:76:9: warning: variable 'stack' was never mutated; consider changing to 'let' constant
    var stack = [4, 3, 8, 9, 1, 7, 6, 5, 2]
    ~~~ ^
    let
/mnt/exercism-iteration/Tests/MagicianInTrainingTests/MagicianInTrainingTests.swift:82:9: warning: variable 'stack' was never mutated; consider changing to 'let' constant
    var stack = [8, 7, 4, 2, 6, 5, 3, 1, 9]
    ~~~ ^
    let
/mnt/exercism-iteration/Tests/MagicianInTrainingTests/MagicianInTrainingTests.swift:88:9: warning: variable 'stack' was never mutated; consider changing to 'let' constant
    var stack = [Int]()
    ~~~ ^
    let
/mnt/exercism-iteration/Tests/MagicianInTrainingTests/MagicianInTrainingTests.swift:100:9: warning: variable 'stack' was never mutated; consider changing to 'let' constant
    var stack = [6, 9, 7, 8, 2, 3, 4, 5, 1]
    ~~~ ^
    let
[9/12] Merging module MagicianInTrainingTests
[11/13] Wrapping AST for MagicianInTrainingTests for debugging
[12/14] Compiling MagicianInTrainingPackageTests LinuxMain.swift
[14/16] Merging module MagicianInTrainingPackageTests
[16/17] Wrapping AST for MagicianInTrainingPackageTests for debugging
[17/17] Linking MagicianInTrainingPackageTests.xctest
[17/17] Build complete!
Test Suite 'All tests' started at 2022-05-11 07:20:44.358
Test Suite 'debug.xctest' started at 2022-05-11 07:20:44.383
Test Suite 'MagicianInTrainingTests' started at 2022-05-11 07:20:44.383
Test Case 'MagicianInTrainingTests.testGetCard' started at 2022-05-11 07:20:44.383
Test Case 'MagicianInTrainingTests.testGetCard' passed (0.002 seconds)
Test Case 'MagicianInTrainingTests.testSetCard' started at 2022-05-11 07:20:44.386
Test Case 'MagicianInTrainingTests.testSetCard' passed (0.0 seconds)
Test Case 'MagicianInTrainingTests.testSetCardIndexTooLow' started at 2022-05-11 07:20:44.386
Test Case 'MagicianInTrainingTests.testSetCardIndexTooLow' passed (0.0 seconds)
Test Case 'MagicianInTrainingTests.testSetCardIndexTooHigh' started at 2022-05-11 07:20:44.386
Test Case 'MagicianInTrainingTests.testSetCardIndexTooHigh' passed (0.0 seconds)
Test Case 'MagicianInTrainingTests.testInsertAtTop' started at 2022-05-11 07:20:44.386
Test Case 'MagicianInTrainingTests.testInsertAtTop' passed (0.0 seconds)
Test Case 'MagicianInTrainingTests.testRemoveCard' started at 2022-05-11 07:20:44.386
Test Case 'MagicianInTrainingTests.testRemoveCard' passed (0.0 seconds)
Test Case 'MagicianInTrainingTests.testRemoveCardIndexTooLow' started at 2022-05-11 07:20:44.386
Test Case 'MagicianInTrainingTests.testRemoveCardIndexTooLow' passed (0.0 seconds)
Test Case 'MagicianInTrainingTests.testRemoveCardIndexTooHigh' started at 2022-05-11 07:20:44.386
Test Case 'MagicianInTrainingTests.testRemoveCardIndexTooHigh' passed (0.0 seconds)
Test Case 'MagicianInTrainingTests.testRemoveTopCard' started at 2022-05-11 07:20:44.386
Test Case 'MagicianInTrainingTests.testRemoveTopCard' passed (0.0 seconds)
Test Case 'MagicianInTrainingTests.testRemoveTopCardFromEmptyStack' started at 2022-05-11 07:20:44.386
Test Case 'MagicianInTrainingTests.testRemoveTopCardFromEmptyStack' passed (0.0 seconds)
Test Case 'MagicianInTrainingTests.testInsertAtBottom' started at 2022-05-11 07:20:44.386
Test Case 'MagicianInTrainingTests.testInsertAtBottom' passed (0.0 seconds)
Test Case 'MagicianInTrainingTests.testRemoveBottomCard' started at 2022-05-11 07:20:44.387
Test Case 'MagicianInTrainingTests.testRemoveBottomCard' passed (0.0 seconds)
Test Case 'MagicianInTrainingTests.testRemoveBottomCardFromEmptyStack' started at 2022-05-11 07:20:44.387
Test Case 'MagicianInTrainingTests.testRemoveBottomCardFromEmptyStack' passed (0.0 seconds)
Test Case 'MagicianInTrainingTests.testCheckSizeTrue' started at 2022-05-11 07:20:44.387
Test Case 'MagicianInTrainingTests.testCheckSizeTrue' passed (0.0 seconds)
Test Case 'MagicianInTrainingTests.testCheckSizeFalse' started at 2022-05-11 07:20:44.387
Test Case 'MagicianInTrainingTests.testCheckSizeFalse' passed (0.0 seconds)
Test Case 'MagicianInTrainingTests.testEvenCardCount' started at 2022-05-11 07:20:44.387
Test Case 'MagicianInTrainingTests.testEvenCardCount' passed (0.0 seconds)
Test Case 'MagicianInTrainingTests.testEvenCardCountZero' started at 2022-05-11 07:20:44.387
Test Case 'MagicianInTrainingTests.testEvenCardCountZero' passed (0.0 seconds)
Test Suite 'MagicianInTrainingTests' passed at 2022-05-11 07:20:44.387
	 Executed 17 tests, with 0 failures (0 unexpected) in 0.004 (0.004) seconds
Test Suite 'debug.xctest' passed at 2022-05-11 07:20:44.387
	 Executed 17 tests, with 0 failures (0 unexpected) in 0.004 (0.004) seconds
Test Suite 'All tests' passed at 2022-05-11 07:20:44.387
	 Executed 17 tests, with 0 failures (0 unexpected) in 0.004 (0.004) seconds
```
