### PR TITLE
Add () to forward @autoclosure parameter

### DIFF
--- a/exercises/concept/lasagna/Tests/LasagnaTests/LasagnaTests.swift
+++ b/exercises/concept/lasagna/Tests/LasagnaTests/LasagnaTests.swift
@@ -5,7 +5,7 @@ final class LasagnaTests: XCTestCase {
   let runAll = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"]) ?? false
 
   func testExpectedMinutes() {
-    XCTAssertEqual(expectedMinutesInOven, 40)
+    XCTAssertEqual(expectedMinutesInOven(), 40)
   }
 
   func testRemainingMinutes() throws {


### PR DESCRIPTION
Fix test blocking error:
```
/mnt/exercism-iteration/Tests/LasagnaTests/LasagnaTests.swift:8:20: error: add () to forward @autoclosure parameter
    XCTAssertEqual(expectedMinutesInOven, 40)
                   ^~~~~~~~~~~~~~~~~~~~~
                                        ()
[7/10] Compiling LasagnaTests XCTestManifests.swift
error: fatalError
```