### PR TITLE
Update HighScoreBoardTests

### DIFF
--- a/exercises/concept/high-score-board/Tests/HighScoreBoardTests/HighScoreBoardTests.swift
+++ b/exercises/concept/high-score-board/Tests/HighScoreBoardTests/HighScoreBoardTests.swift
@@ -88,7 +88,7 @@ final class HighScoreBoardTests: XCTestCase {
     addPlayer(&scoreboard, "Amil PAstorius", 99373)
     addPlayer(&scoreboard, "Min-seo Shin")
     updateScore(&scoreboard, "Min-seo Shin", 1999)
-    updateScore(&scoreboard, "Jesse Johnson", 1337)
+    updateScore(&scoreboard, "Jesse Johnson", 2674)
     XCTAssertEqual(
       scoreboard,
       ["Jesse Johnson": 2674, "Amil PAstorius": 99373, "Min-seo Shin": 1999],

--- a/exercises/concept/high-score-board/Tests/HighScoreBoardTests/HighScoreBoardTests.swift
+++ b/exercises/concept/high-score-board/Tests/HighScoreBoardTests/HighScoreBoardTests.swift
@@ -103,7 +103,7 @@ final class HighScoreBoardTests: XCTestCase {
     addPlayer(&scoreboard, "Amil PAstorius", 99373)
     addPlayer(&scoreboard, "Min-seo Shin")
     updateScore(&scoreboard, "Min-seo Shin", 1999)
-    updateScore(&scoreboard, "Jesse Johnson", 1337)
+    updateScore(&scoreboard, "Jesse Johnson", 2674)
     let expected = [("Amil PAstorius", 99373), ("Jesse Johnson", 2674), ("Min-seo Shin", 1999)]
     let got = orderByPlayers(scoreboard)
     XCTAssertTrue(


### PR DESCRIPTION
Change `updateScore` test value so it equals to expected result
Fix error from previous changes:
```
XCTAssertEqual failed: ("["Amil PAstorius": 99373, "Min-seo Shin": 1999, "Jesse Johnson": 1337]") is not equal to ("["Amil PAstorius": 99373, "Min-seo Shin": 1999, "Jesse Johnson": 2674]") - Updating a player's score should add the update to their score and leave the rest unchanged.
```