### PR TITLE
bit checking order is reversed in tests

### DIFF
--- a/exercises/concept/bomb-defuser/.docs/instructions.md
+++ b/exercises/concept/bomb-defuser/.docs/instructions.md
@@ -41,7 +41,7 @@ makeShuffle(
 
 which takes as input a closure that flips two wires and a closure that rotates the three wires and returns a closure. This returned closure takes the ID number of the stink-bomb and the order of the three wires, and then computes the order the wires need to be cut. This is computed as follows:
 
-For each bit in the ID number, starting with the leftmost bit, you will apply the `flipper` closure to the wires tuple if the bit is a 0 and you will apply the `rotator` closure if it is a 1 giving the new state of the wires. After the appropriate closures have been applied for all eight bits of the ID, the final state of the wires is the order they need to be cut in.
+For each bit in the ID number, starting with the rightmost bit, you will apply the `flipper` closure to the wires tuple if the bit is a 0 and you will apply the `rotator` closure if it is a 1 giving the new state of the wires. After the appropriate closures have been applied for all eight bits of the ID, the final state of the wires is the order they need to be cut in.
 
 ```swift
 let shuffler = makeShuffle(flipper: flip, rotator: rotate)


### PR DESCRIPTION
I believe the tests for this exercise are written expecting we check the bits from right to left, not left to right as indicated here. `testShuffle1` and `testShuffle3` both pass regardless of which direction we go, but `testShuffle2` fails when going left to right.

If starting with leftmost is the correct behavior, then I believe `testShuffle2` should expect to get `("Purple", "Marigold", "Cyan")` instead of the `("Marigold", "Cyan", "Purple")` it currently wants (I could do a different PR with that change instead of this if that's the right thing).

I might also just be confused and it's correct as is!!