### PR TITLE
Fix typo in guard statement

### DIFF
--- a/exercises/concept/vehicle-purchase/.docs/introduction.md
+++ b/exercises/concept/vehicle-purchase/.docs/introduction.md
@@ -80,7 +80,7 @@ default:
 The `guard` statement in swift is used for early returns from Swift functions when a necessary condition which needs to be met for further processing to continue is not met, e.g.:
 
 ```swift
-guard myValue = 0 else { return 0 }
+guard myValue != 0 else { return 0 }
 let root = myValue.squareRoot()
 ```
 


### PR DESCRIPTION
The guard in the square root example is checking to do an early out if zero is passed; the condition needs to be !=, not assignment.