### PR TITLE
Fixed a (typing) error of code in vehicle purchase exercise

### DIFF
--- a/exercises/concept/vehicle-purchase/.docs/introduction.md
+++ b/exercises/concept/vehicle-purchase/.docs/introduction.md
@@ -80,7 +80,7 @@ default:
 The `guard` statement in swift is used for early returns from Swift functions when a necessary condition which needs to be met for further processing to continue is not met, e.g.:
 
 ```swift
-guard myValue = 0 else { return 0 }
+guard myValue >= 0 else { return 0 }
 let root = myValue.squareRoot()
 ```
 


### PR DESCRIPTION
```swift
guard myValue = 0 else { return 0 }
let root = myValue.squareRoot()
```
The Boolean expression of guard should not be like this and should be consistent with this:
[concepts/conditionals-guard/introduction.md](https://github.com/exercism/swift/blob/55caa3c9d0461d7d04fdaac34eb68396efcd56d3/concepts/conditionals-guard/introduction.md)