### PR TITLE
Fix largest-series-products tests

### DIFF
--- a/exercises/practice/largest-series-product/Tests/LargestSeriesProductTests/LargestSeriesProductTests.swift
+++ b/exercises/practice/largest-series-product/Tests/LargestSeriesProductTests/LargestSeriesProductTests.swift
@@ -85,8 +85,6 @@ class LargestSeriesProductTests: XCTestCase {
             ("testReportsZeroIfTheOnlyDigitsAreZero", testReportsZeroIfTheOnlyDigitsAreZero),
             ("testReportsZeroIfAllSpansIncludeZero", testReportsZeroIfAllSpansIncludeZero),
             ("testRejectsSpanLongerThanStringLength", testRejectsSpanLongerThanStringLength),
-            ("testReports1ForEmptyStringAndEmptyProduct0Span", testReports1ForEmptyStringAndEmptyProduct0Span),
-            ("testReports1ForNonemptyStringAndEmptyProduct0Span", testReports1ForNonemptyStringAndEmptyProduct0Span),
             ("testRejectsEmptyStringAndNonzeroSpan", testRejectsEmptyStringAndNonzeroSpan),
             ("testRejectsInvalidCharacterInDigits", testRejectsInvalidCharacterInDigits),
             ("testRejectsNegativeSpan", testRejectsNegativeSpan),


### PR DESCRIPTION
We deleted a couple of tests from the test suite
but they were still being referenced from allTests.

This deletes the stray references.
