### PR TITLE
Fix name typo Contro -> Control in Swift config.json 

### DIFF
--- a/config.json
+++ b/config.json
@@ -1061,7 +1061,7 @@
     {
       "uuid": "5ab7940e-0eea-435c-b3ac-dc3f77f536cf",
       "slug": "control-transfer",
-      "name": "Contro transfer"
+      "name": "Control transfer"
     },
     {
       "uuid": "290d9abd-355f-48fe-baf0-c5dd6b3b1801",


### PR DESCRIPTION
Fixes title and heading typo on https://exercism.org/tracks/swift/concepts/control-transfer