### PR TITLE
Update default value for runAll variable in tests

### DIFF
--- a/exercises/concept/lasagna/Tests/LasagnaTests/LasagnaTests.swift
+++ b/exercises/concept/lasagna/Tests/LasagnaTests/LasagnaTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import Lasagna
 
-let runAll = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "true"]) ?? true
+let runAll = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"]) ?? false
 
 class TaskExpectedMinutesInOvenTests: XCTestCase {
   func testExpectedMinutes() {


### PR DESCRIPTION
The default value for `runAll` was changed to true which makes all tests run by default, and the comments to change true to false incorrect. Changing it to false also makes it consistent with unit tests in other exercises (at least the 4 I checked).