### PR TITLE
Convert backtick (`) admonition fences to tildes (~)

### DIFF
--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -40,7 +40,7 @@ var implicitVar = 10      // Implicitly typed
 
 Updating a variable's value is done using the `=` operator.
 
-````exercism/note
+~~~~exercism/note
 The type of a variable, is fixed once it is initially defined.
 
 ```swift
@@ -49,7 +49,7 @@ variableName = 13 // update to new value
 // compiler error when assigning a different type
 variableName = "Hello, world!" // Cannot assign value of type 'String' to type 'Int'
 ```
-````
+~~~~
 
 Variables may be declared without assigning a value by specifying the name and type, but they may not be used before a value is assigned.
 

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -26,7 +26,7 @@ var implicitVar = 10      // Implicitly typed
 
 Updating a variable's value is done using the `=` operator.
 
-````exercism/note
+~~~~exercism/note
 The type of a variable, is fixed once it is initially defined.
 
 ```swift
@@ -35,7 +35,7 @@ variableName = 13 // update to new value
 // compiler error when assigning a different type
 variableName = "Hello, world!" // Cannot assign value of type 'String' to type 'Int'
 ```
-````
+~~~~
 
 Variables may be declared without assigning a value by specifying the name and type, but they may not be used before a value is assigned.
 

--- a/concepts/booleans/about.md
+++ b/concepts/booleans/about.md
@@ -55,9 +55,9 @@ Since what is in parentheses is evaluated first, in the following example, the _
 !(true && false) // true
 ```
 
-```exercism/note
+~~~~exercism/note
 You should only use parentheses when they affect the result, otherwise, should they be omitted.
-```
+~~~~
 
 [logical-operators]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/basicoperators/#Logical-Operators
 [not]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/basicoperators/#Logical-NOT-Operator

--- a/concepts/booleans/introduction.md
+++ b/concepts/booleans/introduction.md
@@ -55,9 +55,9 @@ Since what is in parentheses is evaluated first, in the following example, the _
 !(true && false) // true
 ```
 
-```exercism/note
+~~~~exercism/note
 You should only use parentheses when they affect the result, otherwise, should they be omitted.
-```
+~~~~
 
 [logical-operators]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/basicoperators/#Logical-Operators
 [not]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/basicoperators/#Logical-NOT-Operator

--- a/concepts/numbers/about.md
+++ b/concepts/numbers/about.md
@@ -21,10 +21,10 @@ let plancksConstant : Double = 6.62607015e-34 // plancksConstant is a Double
 
 ## Arithmetic operators
 
-```exercism/caution
+~~~~exercism/caution
 In Swift can't mix types in arithmetic operations, so you can't use any arithmetic operator on an `Int` with a `Double` or vice versa.
 Thereby you have to do a type conversion first.
-```
+~~~~
 
 Swift does have a set of [arithmetic operators][arithmetic-operators] that can be used to perform basic mathematical operations.
 The `+` operator is used for addition, the `-` operator is used for subtraction, and the `*` operator is used for multiplication.
@@ -66,10 +66,10 @@ The [`%` operator][reminder-operator] is used to get the remainder of a division
 The operator returns the remainder of the division of the first argument by the second argument.
 And as with division, having the second argument having the value of zero will result in a compile error.
 
-```exercism/note
+~~~~exercism/note
 In other languages, is this operator also known as the modulo operator.
 But in Swift, it does not work the same way as the modulo operator, since it strictly speaking, returns the remainder, not the modulo.
-```
+~~~~
 
 ```swift
 5 % 2  // equals 1

--- a/concepts/numbers/introduction.md
+++ b/concepts/numbers/introduction.md
@@ -21,10 +21,10 @@ let plancksConstant : Double = 6.62607015e-34 // plancksConstant is a Double
 
 ## Arithmetic operators
 
-```exercism/caution
+~~~~exercism/caution
 In Swift can't mix types in arithmetic operations, so you can't use any arithmetic operator on an `Int` with a `Double` or vice versa.
 Thereby you have to do a type conversion first.
-```
+~~~~
 
 Swift does have a set of [arithmetic operators][arithmetic-operators] that can be used to perform basic mathematical operations.
 The `+` operator is used for addition, the `-` operator is used for subtraction, and the `*` operator is used for multiplication.
@@ -66,10 +66,10 @@ The [`%` operator][reminder-operator] is used to get the remainder of a division
 The operator returns the remainder of the division of the first argument by the second argument.
 And as with division, having the second argument having the value of zero will result in a compile error.
 
-```exercism/note
+~~~~exercism/note
 In other languages, is this operator also known as the modulo operator.
 But in Swift, it does not work the same way as the modulo operator, since it strictly speaking, returns the remainder, not the modulo.
-```
+~~~~
 
 ```swift
 5 % 2  // equals 1

--- a/exercises/concept/freelancer-rates/.docs/introduction.md
+++ b/exercises/concept/freelancer-rates/.docs/introduction.md
@@ -21,10 +21,10 @@ let plancksConstant : Double = 6.62607015e-34 // plancksConstant is a Double
 
 ## Arithmetic operators
 
-```exercism/caution
+~~~~exercism/caution
 In Swift can't mix types in arithmetic operations, so you can't use any arithmetic operator on an `Int` with a `Double` or vice versa.
 Thereby you have to do a type conversion first.
-```
+~~~~
 
 Swift does have a set of [arithmetic operators][arithmetic-operators] that can be used to perform basic mathematical operations.
 The `+` operator is used for addition, the `-` operator is used for subtraction, and the `*` operator is used for multiplication.
@@ -66,10 +66,10 @@ The [`%` operator][reminder-operator] is used to get the remainder of a division
 The operator returns the remainder of the division of the first argument by the second argument.
 And as with division, having the second argument having the value of zero will result in a compile error.
 
-```exercism/note
+~~~~exercism/note
 In other languages, is this operator also known as the modulo operator.
 But in Swift, it does not work the same way as the modulo operator, since it strictly speaking, returns the remainder, not the modulo.
-```
+~~~~
 
 ```swift
 5 % 2  // equals 1

--- a/exercises/concept/lasagna/.docs/introduction.md
+++ b/exercises/concept/lasagna/.docs/introduction.md
@@ -26,7 +26,7 @@ var implicitVar = 10      // Implicitly typed
 
 Updating a variable's value is done using the `=` operator.
 
-````exercism/note
+~~~~exercism/note
 The type of a variable, is fixed once it is initially defined.
 
 ```swift
@@ -35,7 +35,7 @@ variableName = 13 // update to new value
 // compiler error when assigning a different type
 variableName = "Hello, world!" // Cannot assign value of type 'String' to type 'Int'
 ```
-````
+~~~~
 
 Variables may be declared without assigning a value by specifying the name and type, but they may not be used before a value is assigned.
 

--- a/exercises/concept/wings-quest/.docs/introduction.md
+++ b/exercises/concept/wings-quest/.docs/introduction.md
@@ -55,9 +55,9 @@ Since what is in parentheses is evaluated first, in the following example, the _
 !(true && false) // true
 ```
 
-```exercism/note
+~~~~exercism/note
 You should only use parentheses when they affect the result, otherwise, should they be omitted.
-```
+~~~~
 
 [logical-operators]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/basicoperators/#Logical-Operators
 [not]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/basicoperators/#Logical-NOT-Operator

--- a/exercises/practice/linked-list/.docs/instructions.md
+++ b/exercises/practice/linked-list/.docs/instructions.md
@@ -13,7 +13,7 @@ Sometimes a station gets closed down, and in that case the station needs to be r
 
 The size of a route is measured not by how far the train travels, but by how many stations it stops at.
 
-```exercism/note
+~~~~exercism/note
 The linked list is a fundamental data structure in computer science, often used in the implementation of other data structures.
 As the name suggests, it is a list of nodes that are linked together.
 It is a list of "nodes", where each node links to its neighbor or neighbors.
@@ -23,4 +23,4 @@ In a **doubly linked list** each node links to both the node that comes before, 
 If you want to dig deeper into linked lists, check out [this article][intro-linked-list] that explains it using nice drawings.
 
 [intro-linked-list]: https://medium.com/basecs/whats-a-linked-list-anyway-part-1-d8b7e6508b9d
-```
+~~~~


### PR DESCRIPTION
In line with Exercism's spec, we're ensuring that all admonition fences are demarcated with four tildes (`~~~~`) across all repositories. We will be following up with an org-wide script that can be used to keep this consistent. [Problem Specifications](https://github.com/exercism/problem-specifications) has already been updated.

We'll automatically merge this a week from now, but feel free to merge beforehand!

- Spec: https://exercism.org/docs/building/markdown/markdown#h-special-blocks-sometimes-called-admonitions
- Meta issue: https://github.com/exercism/exercism/issues/6705