### PR TITLE
LasagnaTests.swift add missing parentheses

### DIFF
--- a/exercises/concept/lasagna/Tests/LasagnaTests/LasagnaTests.swift
+++ b/exercises/concept/lasagna/Tests/LasagnaTests/LasagnaTests.swift
@@ -6,7 +6,7 @@ let runAll = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"
 
 class TaskExpectedMinutesInOvenTests: XCTestCase {
   func testExpectedMinutes() {
-    XCTAssertEqual(expectedMinutesInOven, 40)
+    XCTAssertEqual(expectedMinutesInOven(), 40)
   }
 }
 


### PR DESCRIPTION
I was unable to pass this task due to error
```
/mnt/exercism-iteration/Tests/LasagnaTests/LasagnaTests.swift:9:20: error: add () to forward @autoclosure parameter
    XCTAssertEqual(expectedMinutesInOven, 40)
                   ^~~~~~~~~~~~~~~~~~~~~
                                        ()
error: fatalError
``` 