### PR TITLE
Update HighScoreBoardTests.swift

### DIFF
--- a/exercises/concept/high-score-board/Tests/HighScoreBoardTests/HighScoreBoardTests.swift
+++ b/exercises/concept/high-score-board/Tests/HighScoreBoardTests/HighScoreBoardTests.swift
@@ -81,6 +81,20 @@ final class HighScoreBoardTests: XCTestCase {
     )
   }
 
+  func testResetScoreNonexistentPlayer() throws {
+    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+    var scoreboard = [String: Int]()
+    addPlayer(&scoreboard, "Jesse Johnson", 1337)
+    addPlayer(&scoreboard, "Amil PAstorius", 99373)
+    addPlayer(&scoreboard, "Min-seo Shin")
+    resetScore(&scoreboard, "Bruno Santangelo")
+    XCTAssertEqual(
+      scoreboard,
+      ["Jesse Johnson": 1337, "Amil PAstorius": 99373, "Min-seo Shin": 0],
+      "Resetting a non-existent player's score should leave the dictionary unchanged."
+    )
+  }
+
   func testUpdateScore() throws {
     try XCTSkipIf(true && !runAll)  // change true to false to run this test
     var scoreboard = [String: Int]()


### PR DESCRIPTION
In the High Score Board exercise `resetScore` function is [described as this](https://github.com/exercism/swift/blob/main/exercises/concept/high-score-board/.docs/instructions.md?plain=1#L49):

> The function will set the score of the player to 0. If the player is not in the dictionary, then nothing should happen.

There is no test case to validate resetting nonexistent player's score, which makes this code pass, even though it should not:

```swift
func resetScore(_ scores: inout [String: Int], _ name: String) {
  scores[name] = 0
}
```

This PR adds the missing test case.