### PR TITLE
[Swift 6] Depricate exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -1323,11 +1323,11 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
+        "status": "deprecated",
         "topics": [
           "recursion",
           "transforming"
-        ],
-        "status": "deprecated"
+        ]
       },
       {
         "slug": "scale-generator",
@@ -1336,12 +1336,12 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
+        "status": "deprecated",
         "topics": [
           "loops",
           "pattern_matching",
           "strings"
-        ],
-        "status": "deprecated"
+        ]
       },
       {
         "slug": "beer-song",

--- a/config.json
+++ b/config.json
@@ -258,42 +258,6 @@
     ],
     "practice": [
       {
-        "slug": "binary",
-        "name": "Binary",
-        "uuid": "0930d019-2ccb-48f9-9ee7-467b683d9901",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "status": "deprecated"
-      },
-      {
-        "slug": "hexadecimal",
-        "name": "Hexadecimal",
-        "uuid": "3a9f0e4d-a569-40ea-adb8-ded8d240c949",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "status": "deprecated"
-      },
-      {
-        "slug": "octal",
-        "name": "Octal",
-        "uuid": "128bcbc1-18b3-45e7-9590-c71d8f57c5c1",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "status": "deprecated"
-      },
-      {
-        "slug": "trinary",
-        "name": "Trinary",
-        "uuid": "8b376ef9-ad94-4623-8d0f-e2d7bb6c364a",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "status": "deprecated"
-      },
-      {
         "slug": "difference-of-squares",
         "name": "Difference of Squares",
         "uuid": "ef114733-886b-4d4b-a713-3ba169a85025",
@@ -395,18 +359,6 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1
-      },
-      {
-        "slug": "accumulate",
-        "name": "Accumulate",
-        "uuid": "cb5bc145-8249-4b3b-bcb3-b8d7805f2a14",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2,
-        "topics": [
-          "recursion",
-          "transforming"
-        ]
       },
       {
         "slug": "darts",
@@ -722,19 +674,6 @@
         "topics": [
           "records",
           "tuples"
-        ]
-      },
-      {
-        "slug": "scale-generator",
-        "name": "Scale Generator",
-        "uuid": "1c9dfe22-de66-4437-862b-8921dc7eb25e",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3,
-        "topics": [
-          "loops",
-          "pattern_matching",
-          "strings"
         ]
       },
       {
@@ -1340,6 +1279,69 @@
           "parsing",
           "sorting"
         ]
+      },
+      {
+        "slug": "binary",
+        "name": "Binary",
+        "uuid": "0930d019-2ccb-48f9-9ee7-467b683d9901",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1,
+        "status": "deprecated"
+      },
+      {
+        "slug": "hexadecimal",
+        "name": "Hexadecimal",
+        "uuid": "3a9f0e4d-a569-40ea-adb8-ded8d240c949",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1,
+        "status": "deprecated"
+      },
+      {
+        "slug": "octal",
+        "name": "Octal",
+        "uuid": "128bcbc1-18b3-45e7-9590-c71d8f57c5c1",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1,
+        "status": "deprecated"
+      },
+      {
+        "slug": "trinary",
+        "name": "Trinary",
+        "uuid": "8b376ef9-ad94-4623-8d0f-e2d7bb6c364a",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1,
+        "status": "deprecated"
+      },
+      {
+        "slug": "accumulate",
+        "name": "Accumulate",
+        "uuid": "cb5bc145-8249-4b3b-bcb3-b8d7805f2a14",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 2,
+        "topics": [
+          "recursion",
+          "transforming"
+        ],
+        "status": "deprecated"
+      },
+      {
+        "slug": "scale-generator",
+        "name": "Scale Generator",
+        "uuid": "1c9dfe22-de66-4437-862b-8921dc7eb25e",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3,
+        "topics": [
+          "loops",
+          "pattern_matching",
+          "strings"
+        ],
+        "status": "deprecated"
       },
       {
         "slug": "beer-song",

--- a/exercises/practice/scale-generator/.meta/template.swift
+++ b/exercises/practice/scale-generator/.meta/template.swift
@@ -1,21 +1,23 @@
-import XCTest
+import Testing
+import Foundation
 @testable import {{exercise|camelCase}}
-class {{exercise|camelCase}}Tests: XCTestCase {
-    let runAll = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"]) ?? false
 
+let RUNALL = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"]) ?? false
+
+@Suite struct {{exercise|camelCase}}Tests {
     {% outer: for case in cases %}
         {%- for subCases in case.cases %}
         {%- if forloop.outer.first and forloop.first %}
-            func test{{subCases.description |camelCase }}() {
+            @Test("{{subCases.description}}")
         {%- else %}
-            func test{{subCases.description |camelCase }}() throws {
-            try XCTSkipIf(true && !runAll) // change true to false to run this test
+            @Test("{{subCases.description}}", .enabled(if: RUNALL))
         {%- endif %}
+            func test{{subCases.description |camelCase }}() {
         let scaleGenerator = ScaleGenerator(tonic: "{{subCases.input.tonic}}")
         {%- if subCases.property == "chromatic" %}
-            XCTAssertEqual(scaleGenerator.{{subCases.property}}(), {{subCases.expected | toStringArray }})
+            #expect(scaleGenerator.{{subCases.property}}() == {{subCases.expected | toStringArray }})
         {%- else %}
-            XCTAssertEqual(scaleGenerator.{{subCases.property}}("{{subCases.input.intervals}}"), {{subCases.expected | toStringArray }})
+            #expect(scaleGenerator.{{subCases.property}}("{{subCases.input.intervals}}") == {{subCases.expected | toStringArray }})
         {%- endif %}
         }
         {% endfor -%}

--- a/exercises/practice/scale-generator/Package.swift
+++ b/exercises/practice/scale-generator/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:6.0
 
 import PackageDescription
 

--- a/exercises/practice/scale-generator/Tests/ScaleGeneratorTests/ScaleGeneratorTests.swift
+++ b/exercises/practice/scale-generator/Tests/ScaleGeneratorTests/ScaleGeneratorTests.swift
@@ -1,117 +1,118 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import ScaleGenerator
 
-class ScaleGeneratorTests: XCTestCase {
-  let runAll = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"]) ?? false
+let RUNALL = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"]) ?? false
 
+@Suite struct ScaleGeneratorTests {
+
+  @Test("Chromatic scale with sharps")
   func testChromaticScaleWithSharps() {
     let scaleGenerator = ScaleGenerator(tonic: "C")
-    XCTAssertEqual(
-      scaleGenerator.chromatic(), ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"])
+    #expect(
+      scaleGenerator.chromatic() == [
+        "C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B",
+      ])
   }
 
-  func testChromaticScaleWithFlats() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Chromatic scale with flats", .enabled(if: RUNALL))
+  func testChromaticScaleWithFlats() {
     let scaleGenerator = ScaleGenerator(tonic: "F")
-    XCTAssertEqual(
-      scaleGenerator.chromatic(), ["F", "Gb", "G", "Ab", "A", "Bb", "B", "C", "Db", "D", "Eb", "E"])
+    #expect(
+      scaleGenerator.chromatic() == [
+        "F", "Gb", "G", "Ab", "A", "Bb", "B", "C", "Db", "D", "Eb", "E",
+      ])
   }
 
-  func testSimpleMajorScale() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Simple major scale", .enabled(if: RUNALL))
+  func testSimpleMajorScale() {
     let scaleGenerator = ScaleGenerator(tonic: "C")
-    XCTAssertEqual(scaleGenerator.interval("MMmMMMm"), ["C", "D", "E", "F", "G", "A", "B", "C"])
+    #expect(scaleGenerator.interval("MMmMMMm") == ["C", "D", "E", "F", "G", "A", "B", "C"])
   }
 
-  func testMajorScaleWithSharps() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Major scale with sharps", .enabled(if: RUNALL))
+  func testMajorScaleWithSharps() {
     let scaleGenerator = ScaleGenerator(tonic: "G")
-    XCTAssertEqual(scaleGenerator.interval("MMmMMMm"), ["G", "A", "B", "C", "D", "E", "F#", "G"])
+    #expect(scaleGenerator.interval("MMmMMMm") == ["G", "A", "B", "C", "D", "E", "F#", "G"])
   }
 
-  func testMajorScaleWithFlats() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Major scale with flats", .enabled(if: RUNALL))
+  func testMajorScaleWithFlats() {
     let scaleGenerator = ScaleGenerator(tonic: "F")
-    XCTAssertEqual(scaleGenerator.interval("MMmMMMm"), ["F", "G", "A", "Bb", "C", "D", "E", "F"])
+    #expect(scaleGenerator.interval("MMmMMMm") == ["F", "G", "A", "Bb", "C", "D", "E", "F"])
   }
 
-  func testMinorScaleWithSharps() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Minor scale with sharps", .enabled(if: RUNALL))
+  func testMinorScaleWithSharps() {
     let scaleGenerator = ScaleGenerator(tonic: "f#")
-    XCTAssertEqual(
-      scaleGenerator.interval("MmMMmMM"), ["F#", "G#", "A", "B", "C#", "D", "E", "F#"])
+    #expect(scaleGenerator.interval("MmMMmMM") == ["F#", "G#", "A", "B", "C#", "D", "E", "F#"])
   }
 
-  func testMinorScaleWithFlats() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Minor scale with flats", .enabled(if: RUNALL))
+  func testMinorScaleWithFlats() {
     let scaleGenerator = ScaleGenerator(tonic: "bb")
-    XCTAssertEqual(
-      scaleGenerator.interval("MmMMmMM"), ["Bb", "C", "Db", "Eb", "F", "Gb", "Ab", "Bb"])
+    #expect(scaleGenerator.interval("MmMMmMM") == ["Bb", "C", "Db", "Eb", "F", "Gb", "Ab", "Bb"])
   }
 
-  func testDorianMode() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Dorian mode", .enabled(if: RUNALL))
+  func testDorianMode() {
     let scaleGenerator = ScaleGenerator(tonic: "d")
-    XCTAssertEqual(scaleGenerator.interval("MmMMMmM"), ["D", "E", "F", "G", "A", "B", "C", "D"])
+    #expect(scaleGenerator.interval("MmMMMmM") == ["D", "E", "F", "G", "A", "B", "C", "D"])
   }
 
-  func testMixolydianMode() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Mixolydian mode", .enabled(if: RUNALL))
+  func testMixolydianMode() {
     let scaleGenerator = ScaleGenerator(tonic: "Eb")
-    XCTAssertEqual(
-      scaleGenerator.interval("MMmMMmM"), ["Eb", "F", "G", "Ab", "Bb", "C", "Db", "Eb"])
+    #expect(scaleGenerator.interval("MMmMMmM") == ["Eb", "F", "G", "Ab", "Bb", "C", "Db", "Eb"])
   }
 
-  func testLydianMode() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Lydian mode", .enabled(if: RUNALL))
+  func testLydianMode() {
     let scaleGenerator = ScaleGenerator(tonic: "a")
-    XCTAssertEqual(
-      scaleGenerator.interval("MMMmMMm"), ["A", "B", "C#", "D#", "E", "F#", "G#", "A"])
+    #expect(scaleGenerator.interval("MMMmMMm") == ["A", "B", "C#", "D#", "E", "F#", "G#", "A"])
   }
 
-  func testPhrygianMode() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Phrygian mode", .enabled(if: RUNALL))
+  func testPhrygianMode() {
     let scaleGenerator = ScaleGenerator(tonic: "e")
-    XCTAssertEqual(scaleGenerator.interval("mMMMmMM"), ["E", "F", "G", "A", "B", "C", "D", "E"])
+    #expect(scaleGenerator.interval("mMMMmMM") == ["E", "F", "G", "A", "B", "C", "D", "E"])
   }
 
-  func testLocrianMode() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Locrian mode", .enabled(if: RUNALL))
+  func testLocrianMode() {
     let scaleGenerator = ScaleGenerator(tonic: "g")
-    XCTAssertEqual(
-      scaleGenerator.interval("mMMmMMM"), ["G", "Ab", "Bb", "C", "Db", "Eb", "F", "G"])
+    #expect(scaleGenerator.interval("mMMmMMM") == ["G", "Ab", "Bb", "C", "Db", "Eb", "F", "G"])
   }
 
-  func testHarmonicMinor() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Harmonic minor", .enabled(if: RUNALL))
+  func testHarmonicMinor() {
     let scaleGenerator = ScaleGenerator(tonic: "d")
-    XCTAssertEqual(scaleGenerator.interval("MmMMmAm"), ["D", "E", "F", "G", "A", "Bb", "Db", "D"])
+    #expect(scaleGenerator.interval("MmMMmAm") == ["D", "E", "F", "G", "A", "Bb", "Db", "D"])
   }
 
-  func testOctatonic() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Octatonic", .enabled(if: RUNALL))
+  func testOctatonic() {
     let scaleGenerator = ScaleGenerator(tonic: "C")
-    XCTAssertEqual(
-      scaleGenerator.interval("MmMmMmMm"), ["C", "D", "D#", "F", "F#", "G#", "A", "B", "C"])
+    #expect(
+      scaleGenerator.interval("MmMmMmMm") == ["C", "D", "D#", "F", "F#", "G#", "A", "B", "C"])
   }
 
-  func testHexatonic() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Hexatonic", .enabled(if: RUNALL))
+  func testHexatonic() {
     let scaleGenerator = ScaleGenerator(tonic: "Db")
-    XCTAssertEqual(scaleGenerator.interval("MMMMMM"), ["Db", "Eb", "F", "G", "A", "B", "Db"])
+    #expect(scaleGenerator.interval("MMMMMM") == ["Db", "Eb", "F", "G", "A", "B", "Db"])
   }
 
-  func testPentatonic() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Pentatonic", .enabled(if: RUNALL))
+  func testPentatonic() {
     let scaleGenerator = ScaleGenerator(tonic: "A")
-    XCTAssertEqual(scaleGenerator.interval("MMAMA"), ["A", "B", "C#", "E", "F#", "A"])
+    #expect(scaleGenerator.interval("MMAMA") == ["A", "B", "C#", "E", "F#", "A"])
   }
 
-  func testEnigmatic() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Enigmatic", .enabled(if: RUNALL))
+  func testEnigmatic() {
     let scaleGenerator = ScaleGenerator(tonic: "G")
-    XCTAssertEqual(
-      scaleGenerator.interval("mAMMMmm"), ["G", "G#", "B", "C#", "D#", "F", "F#", "G"])
+    #expect(scaleGenerator.interval("mAMMMmm") == ["G", "G#", "B", "C#", "D#", "F", "F#", "G"])
   }
 }


### PR DESCRIPTION
Move deprecated exercises to the end.

Mark `accumulate` and `scale-generator` as depricated.

Scale generator will be updated to be compatible with 6.0.