### PR TITLE
Remove obsolete Syntax

### DIFF
--- a/exercises/concept/bomb-defuser/.meta/Sources/BombDefuser/BombDefuserExemplar.swift
+++ b/exercises/concept/bomb-defuser/.meta/Sources/BombDefuser/BombDefuserExemplar.swift
@@ -1,9 +1,11 @@
-let flip = { (tuple: (String, String, String)) -> (String, String, String) in
+typealias RotationClosure = @Sendable ((String, String, String)) -> (String, String, String)
+
+let flip: RotationClosure = { (tuple: (String, String, String)) -> (String, String, String) in
   let (a, b, c) = tuple
   return (b, a, c)
 }
 
-let rotate = { (tuple: (String, String, String)) -> (String, String, String) in
+let rotate: RotationClosure = { (tuple: (String, String, String)) -> (String, String, String) in
   let (a, b, c) = tuple
   return (b, c, a)
 }

--- a/exercises/concept/bomb-defuser/Tests/BombDefuserTests/BombDefuserTests.swift
+++ b/exercises/concept/bomb-defuser/Tests/BombDefuserTests/BombDefuserTests.swift
@@ -55,12 +55,4 @@ final class BombDefuserTests: XCTestCase {
       stringify(expected), stringify(got),
       "shuffle(0, (\"Brown\", \"Orange\", \"White\")): Expected \(expected), got \(got)")
   }
-
-  static var allTests = [
-    ("testFlip", testFlip),
-    ("testRotate", testRotate),
-    ("testShuffle1", testShuffle1),
-    ("testShuffle2", testShuffle2),
-    ("testShuffle3", testShuffle3),
-  ]
 }

--- a/exercises/concept/bomb-defuser/Tests/BombDefuserTests/XCTestManifests.swift
+++ b/exercises/concept/bomb-defuser/Tests/BombDefuserTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-  public func allTests() -> [XCTestCaseEntry] {
-    return [
-      testCase(BombDefuserTests.allTests)
-    ]
-  }
-#endif

--- a/exercises/concept/bomb-defuser/Tests/LinuxMain.swift
+++ b/exercises/concept/bomb-defuser/Tests/LinuxMain.swift
@@ -1,6 +1,0 @@
-import BombDefuserTests
-import XCTest
-
-var tests = [XCTestCaseEntry]()
-tests += BombDefuserTests.allTests()
-XCTMain(tests)

--- a/exercises/concept/high-score-board/Tests/HighScoreBoardTests/HighScoreBoardTests.swift
+++ b/exercises/concept/high-score-board/Tests/HighScoreBoardTests/HighScoreBoardTests.swift
@@ -140,16 +140,4 @@ final class HighScoreBoardTests: XCTestCase {
       "Expected: \(expected)\nGot: \(got)\norderByPlayers should return the key/value pairs odered ascending by the player's score."
     )
   }
-
-  static var allTests = [
-    ("testEmptyScores", testEmptyScores),
-    ("testAddPlayerExplicit", testAddPlayerExplicit),
-    ("testAddPlayerDefault", testAddPlayerDefault),
-    ("testRemovePlayer", testRemovePlayer),
-    ("testRemoveNonexistentPlayer", testRemoveNonexistentPlayer),
-    ("testResetScore", testResetScore),
-    ("testUpdateScore", testUpdateScore),
-    ("testOrderByPlayers", testOrderByPlayers),
-    ("testOrderByScores", testOrderByScores),
-  ]
 }

--- a/exercises/concept/high-score-board/Tests/HighScoreBoardTests/XCTestManifests.swift
+++ b/exercises/concept/high-score-board/Tests/HighScoreBoardTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-  public func allTests() -> [XCTestCaseEntry] {
-    return [
-      testCase(HighScoreBoardTests.allTests)
-    ]
-  }
-#endif

--- a/exercises/concept/high-score-board/Tests/LinuxMain.swift
+++ b/exercises/concept/high-score-board/Tests/LinuxMain.swift
@@ -1,6 +1,0 @@
-import HighScoreBoardTests
-import XCTest
-
-var tests = [XCTestCaseEntry]()
-tests += HighScoreBoardTests.allTests()
-XCTMain(tests)

--- a/exercises/concept/lasagna-master/Tests/LasagnaMasterTests/LasagnaMasterTests.swift
+++ b/exercises/concept/lasagna-master/Tests/LasagnaMasterTests/LasagnaMasterTests.swift
@@ -81,18 +81,4 @@ final class LasagnaMasterTests: XCTestCase {
         layers: "sauce", "noodles", "béchamel", "meat", "mozzarella", "noodles", "sauce", "ricotta",
         "eggplant", "mozzarella", "béchamel", "noodles", "meat", "sauce", "mozzarella"))
   }
-
-  static var allTests = [
-    ("testRemainingMinutesExplicit", testRemainingMinutesExplicit),
-    ("testRemainingMinutesDefault", testRemainingMinutesDefault),
-    ("testPreparationTime", testPreparationTime),
-    ("testPreparationTimeEmpty", testPreparationTimeEmpty),
-    ("testQuantities", testQuantities),
-    ("testQuantitiesNoSauce", testQuantitiesNoSauce),
-    ("testQuantitiesNoNoodles", testQuantitiesNoNoodles),
-    ("testToOz", testToOz),
-    ("testRedWineRedInequalLayerCount", testRedWineRedInequalLayerCount),
-    ("testRedWineRedEqualLayerCount", testRedWineRedEqualLayerCount),
-    ("testRedWineWhite", testRedWineWhite),
-  ]
 }

--- a/exercises/concept/lasagna-master/Tests/LasagnaMasterTests/XCTestManifests.swift
+++ b/exercises/concept/lasagna-master/Tests/LasagnaMasterTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-  public func allTests() -> [XCTestCaseEntry] {
-    return [
-      testCase(LasagnaMasterTests.allTests)
-    ]
-  }
-#endif

--- a/exercises/concept/lasagna-master/Tests/LinuxMain.swift
+++ b/exercises/concept/lasagna-master/Tests/LinuxMain.swift
@@ -1,6 +1,0 @@
-import LasagnaMasterTests
-import XCTest
-
-var tests = [XCTestCaseEntry]()
-tests += LasagnaMasterTests.allTests()
-XCTMain(tests)

--- a/exercises/concept/log-lines/Tests/LinuxMain.swift
+++ b/exercises/concept/log-lines/Tests/LinuxMain.swift
@@ -1,6 +1,0 @@
-import LogLinesTests
-import XCTest
-
-var tests = [XCTestCaseEntry]()
-tests += LogLinesTests.allTests()
-XCTMain(tests)

--- a/exercises/concept/log-lines/Tests/LogLinesTests/LogLinesTests.swift
+++ b/exercises/concept/log-lines/Tests/LogLinesTests/LogLinesTests.swift
@@ -95,22 +95,4 @@ final class LogLinesTests: XCTestCase {
     let message = "Wha happon?"
     XCTAssertEqual(LogLevel.unknown.shortFormat(message: message), "42:Wha happon?")
   }
-
-  static var allTests = [
-    ("testInitTrace", testInitTrace),
-    ("testInitDebug", testInitDebug),
-    ("testInitInfo", testInitInfo),
-    ("testInitWarning", testInitWarning),
-    ("testInitError", testInitError),
-    ("testInitFatal", testInitFatal),
-    ("testInitUnknownEmpty", testInitUnknownEmpty),
-    ("testInitUnknownNonStandard", testInitUnknownNonStandard),
-    ("testShortTrace", testShortTrace),
-    ("testShortDebug", testShortDebug),
-    ("testShortInfo", testShortInfo),
-    ("testShortWarning", testShortWarning),
-    ("testShortError", testShortError),
-    ("testShortFatal", testShortFatal),
-    ("testShortUnknownEmpty", testShortUnknownEmpty),
-  ]
 }

--- a/exercises/concept/log-lines/Tests/LogLinesTests/XCTestManifests.swift
+++ b/exercises/concept/log-lines/Tests/LogLinesTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-  public func allTests() -> [XCTestCaseEntry] {
-    return [
-      testCase(LogLinesTests.allTests)
-    ]
-  }
-#endif

--- a/exercises/concept/magician-in-training/Tests/LinuxMain.swift
+++ b/exercises/concept/magician-in-training/Tests/LinuxMain.swift
@@ -1,6 +1,0 @@
-import MagicianInTrainingTests
-import XCTest
-
-var tests = [XCTestCaseEntry]()
-tests += MagicianInTrainingTests.allTests()
-XCTMain(tests)

--- a/exercises/concept/magician-in-training/Tests/MagicianInTrainingTests/XCTestManifests.swift
+++ b/exercises/concept/magician-in-training/Tests/MagicianInTrainingTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-  public func allTests() -> [XCTestCaseEntry] {
-    return [
-      testCase(MagicianInTrainingTests.allTests)
-    ]
-  }
-#endif

--- a/exercises/concept/master-mixologist/Tests/LinuxMain.swift
+++ b/exercises/concept/master-mixologist/Tests/LinuxMain.swift
@@ -1,6 +1,0 @@
-import MasterMixologistTests
-import XCTest
-
-var tests = [XCTestCaseEntry]()
-tests += MasterMixologistTests.allTests()
-XCTMain(tests)

--- a/exercises/concept/master-mixologist/Tests/MasterMixologistTests/MasterMixologistTests.swift
+++ b/exercises/concept/master-mixologist/Tests/MasterMixologistTests/MasterMixologistTests.swift
@@ -153,20 +153,4 @@ final class MasterMixologistTests: XCTestCase {
       checkTest(e: expectedBeers, g: got.beer) && checkTest(e: expectedSodas, g: got.soda),
       "Expected (beer: nil, soda: nil), got: \(got)")
   }
-
-  static var allTests = [
-    ("testTimeToPrepare", testTimeToPrepare),
-    ("testMakeWedges", testMakeWedges),
-    ("testMakeWedgesNoNeed", testMakeWedgesNoNeed),
-    ("testMakeWedgesNoLimes", testMakeWedgesNoLimes),
-    ("testMakeWedgesTooFewLimes", testMakeWedgesTooFewLimes),
-    ("testFinishShift", testFinishShift),
-    ("testFinishShiftJustRunOver", testFinishShiftJustRunOver),
-    ("testFinishShiftLeaveEarly", testFinishShiftLeaveEarly),
-    ("testOrderTracker", testOrderTracker),
-    ("testOrderOneEach", testOrderOneEach),
-    ("testOrderTrackerNoBeer", testOrderTrackerNoBeer),
-    ("testOrderTrackerNoSoda", testOrderTrackerNoSoda),
-    ("testOrderTrackerNils", testOrderTrackerNils),
-  ]
 }

--- a/exercises/concept/master-mixologist/Tests/MasterMixologistTests/XCTestManifests.swift
+++ b/exercises/concept/master-mixologist/Tests/MasterMixologistTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-  public func allTests() -> [XCTestCaseEntry] {
-    return [
-      testCase(MasterMixologistTests.allTests)
-    ]
-  }
-#endif

--- a/exercises/concept/pizza-slices/Tests/LinuxMain.swift
+++ b/exercises/concept/pizza-slices/Tests/LinuxMain.swift
@@ -1,6 +1,0 @@
-import PizzaSlicesTests
-import XCTest
-
-var tests = [XCTestCaseEntry]()
-tests += PizzaSlicesTests.allTests()
-XCTMain(tests)

--- a/exercises/concept/pizza-slices/Tests/PizzaSlicesTests/PizzaSlicesTests.swift
+++ b/exercises/concept/pizza-slices/Tests/PizzaSlicesTests/PizzaSlicesTests.swift
@@ -71,19 +71,4 @@ final class PizzaSlicesTests: XCTestCase {
     let biggest = biggestSlice(diameterA: "0", slicesA: "8", diameterB: "16 inches", slicesB: "8")
     XCTAssertEqual(biggest, "Slice A is bigger")
   }
-
-  static var allTests = [
-    ("testSliceNormal", testSliceNormal),
-    ("testSliceNilDiameter", testSliceNilDiameter),
-    ("testSliceNilSlices", testSliceNilSlices),
-    ("testSliceBadDiameter", testSliceBadDiameter),
-    ("testSliceBadSlices", testSliceBadSlices),
-    ("testABiggest", testABiggest),
-    ("testBBiggest", testBBiggest),
-    ("testBothSame", testBothSame),
-    ("testANil", testANil),
-    ("testBNil", testBNil),
-    ("testBothNil", testBothNil),
-    ("testZeroIsValid", testZeroIsValid),
-  ]
 }

--- a/exercises/concept/pizza-slices/Tests/PizzaSlicesTests/XCTestManifests.swift
+++ b/exercises/concept/pizza-slices/Tests/PizzaSlicesTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-  public func allTests() -> [XCTestCaseEntry] {
-    return [
-      testCase(PizzaSlicesTests.allTests)
-    ]
-  }
-#endif

--- a/exercises/concept/poetry-club/Tests/LinuxMain.swift
+++ b/exercises/concept/poetry-club/Tests/LinuxMain.swift
@@ -1,6 +1,0 @@
-import PoetryClubTests
-import XCTest
-
-var tests = [XCTestCaseEntry]()
-tests += PoetryClubTests.allTests()
-XCTMain(tests)

--- a/exercises/concept/poetry-club/Tests/PoetryClubTests/PoetryClubTests.swift
+++ b/exercises/concept/poetry-club/Tests/PoetryClubTests/PoetryClubTests.swift
@@ -79,20 +79,4 @@ final class PoetryClubTests: XCTestCase {
     try XCTSkipIf(true && !runAll)  // change true to false to run this test
     XCTAssertEqual(secretRoomPassword("Open Sesame"), "OPEN SESAME!")
   }
-
-  static var allTests = [
-    ("testSplitNewlines", testSplitNewlines),
-    ("testSplitNoNewlines", testSplitNoNewlines),
-    ("testFirstLetter", testFirstLetter),
-    ("testFirstLetterEmpty", testFirstLetterEmpty),
-    ("testCapitalize", testCapitalize),
-    ("testTrimWithWhitespace", testTrimWithWhitespace),
-    ("testTrimWithoutWhitespace", testTrimWithoutWhitespace),
-    ("testLastLetter", testLastLetter),
-    ("testLastLetterEmpty", testLastLetterEmpty),
-    ("testBackdoorPassword", testBackdoorPassword),
-    ("testIthLetter", testIthLetter),
-    ("testIthLetterInvalid", testIthLetterInvalid),
-    ("testSecretRoomPassword", testSecretRoomPassword),
-  ]
 }

--- a/exercises/concept/poetry-club/Tests/PoetryClubTests/XCTestManifests.swift
+++ b/exercises/concept/poetry-club/Tests/PoetryClubTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-  public func allTests() -> [XCTestCaseEntry] {
-    return [
-      testCase(PoetryClubTests.allTests)
-    ]
-  }
-#endif

--- a/exercises/concept/santas-helper/Tests/LinuxMain.swift
+++ b/exercises/concept/santas-helper/Tests/LinuxMain.swift
@@ -1,6 +1,0 @@
-import SantasHelperTests
-import XCTest
-
-var tests = [XCTestCaseEntry]()
-tests += SantasHelperTests.allTests()
-XCTMain(tests)

--- a/exercises/concept/santas-helper/Tests/SantasHelperTests/SantasHelperTests.swift
+++ b/exercises/concept/santas-helper/Tests/SantasHelperTests/SantasHelperTests.swift
@@ -47,9 +47,4 @@ final class SantasHelperTests: XCTestCase {
         && actual.recipients == recipients
     )
   }
-  static var allTests = [
-    ("testCartesianToPolar", testCartesianToPolar),
-    ("testCartesianToPolarQ3", testCartesianToPolarQ3),
-    ("testCombineRecords", testCombineRecords),
-  ]
 }

--- a/exercises/concept/santas-helper/Tests/SantasHelperTests/XCTestManifests.swift
+++ b/exercises/concept/santas-helper/Tests/SantasHelperTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-  public func allTests() -> [XCTestCaseEntry] {
-    return [
-      testCase(SantasHelperTests.allTests)
-    ]
-  }
-#endif

--- a/exercises/concept/secret-agent/Tests/LinuxMain.swift
+++ b/exercises/concept/secret-agent/Tests/LinuxMain.swift
@@ -1,6 +1,0 @@
-import SecretAgentTests
-import XCTest
-
-var tests = [XCTestCaseEntry]()
-tests += SecretAgentTests.allTests()
-XCTMain(tests)

--- a/exercises/concept/secret-agent/Tests/SecretAgentTests/SecretAgentTests.swift
+++ b/exercises/concept/secret-agent/Tests/SecretAgentTests/SecretAgentTests.swift
@@ -34,11 +34,4 @@ final class SecretAgentTests: XCTestCase {
       })
     XCTAssertTrue(combo == (234, 91, 148))
   }
-
-  static var allTests = [
-    ("testPasswordSuccess", testPasswordSuccess),
-    ("testPasswordFail", testPasswordFail),
-    ("testCombination1", testCombination1),
-    ("testCombination2", testCombination2),
-  ]
 }

--- a/exercises/concept/secret-agent/Tests/SecretAgentTests/XCTestManifests.swift
+++ b/exercises/concept/secret-agent/Tests/SecretAgentTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-  public func allTests() -> [XCTestCaseEntry] {
-    return [
-      testCase(SecretAgentTests.allTests)
-    ]
-  }
-#endif

--- a/exercises/concept/windowing-system/.meta/Sources/WindowingSystem/WindowingSystemExemplar.swift
+++ b/exercises/concept/windowing-system/.meta/Sources/WindowingSystem/WindowingSystemExemplar.swift
@@ -18,7 +18,7 @@ struct Size {
   }
 }
 
-class Window {
+class Window: @unchecked Sendable  {
   var title = "New Window"
   let screenSize = Size(width: 800, height: 600)
   var size = Size()

--- a/exercises/concept/windowing-system/Tests/LinuxMain.swift
+++ b/exercises/concept/windowing-system/Tests/LinuxMain.swift
@@ -1,6 +1,0 @@
-import WindowingSystemTests
-import XCTest
-
-var tests = [XCTestCaseEntry]()
-tests += WindowingSystemTests.allTests()
-XCTMain(tests)

--- a/exercises/concept/windowing-system/Tests/WindowingSystemTests/WindowingSystemTests.swift
+++ b/exercises/concept/windowing-system/Tests/WindowingSystemTests/WindowingSystemTests.swift
@@ -158,18 +158,4 @@ final class WindowingSystemTests: XCTestCase {
       window.display(),
       "New Window\nPosition: (0, 0), Size: (80 x 60)\n[This window intentionally left blank]\n")
   }
-
-  static var allTests = [
-    ("testNewWindow", testNewWindow),
-    ("testMainWindow", testMainWindow),
-    ("testMoveValid", testMoveValid),
-    ("testMoveTooFar", testMoveTooFar),
-    ("testMoveNegative", testMoveNegative),
-    ("testResizeValid", testResizeValid),
-    ("testResizeTooFar", testResizeTooFar),
-    ("testResizeNegative", testResizeNegative),
-    ("testUpdateTitle", testUpdateTitle),
-    ("testUpdateText", testUpdateText),
-    ("testUpdateTextNil", testUpdateTextNil),
-  ]
 }

--- a/exercises/concept/windowing-system/Tests/WindowingSystemTests/XCTestManifests.swift
+++ b/exercises/concept/windowing-system/Tests/WindowingSystemTests/XCTestManifests.swift
@@ -1,9 +1,0 @@
-import XCTest
-
-#if !canImport(ObjectiveC)
-  public func allTests() -> [XCTestCaseEntry] {
-    return [
-      testCase(WindowingSystemTests.allTests)
-    ]
-  }
-#endif


### PR DESCRIPTION
This prs updates most concept exercise to remove obsolete syntax which is incompatible with 6.0, these changes had already been implemented for 6 concept exercises so should be no problem.


Also, the Window system and bomb defuser are fixed to be Swift 6.0 compatible. Both of these exercises will likely change to fit better in Swift 6.0 (and the windowing system has received many complaints) in the future. For now, this is only to pass CI.