### PR TITLE
[Swift 6]: Update window system exercise

### DIFF
--- a/exercises/concept/windowing-system/.docs/hints.md
+++ b/exercises/concept/windowing-system/.docs/hints.md
@@ -20,11 +20,6 @@
 - Constant properties should be defined using `let`.
 - Properties can be changed using their own methods, where available.
 
-## 4. Create some Windows
-
-- This will require the class to be both initialized and modified.
-- Initialization and modification is often done [using a closure][initializing-via-closure]
-
 [structs-and-classes]: https://docs.swift.org/swift-book/LanguageGuide/ClassesAndStructures.html
 [memberwise-initializers]: https://docs.swift.org/swift-book/LanguageGuide/ClassesAndStructures.html#ID87
 [initializing-via-closure]: https://docs.swift.org/swift-book/LanguageGuide/Initialization.html#ID232

--- a/exercises/concept/windowing-system/.docs/instructions.md
+++ b/exercises/concept/windowing-system/.docs/instructions.md
@@ -30,12 +30,12 @@ Define a struct named `Size` with two `Int` properties, `width` and `height` tha
 
 ```swift
 let size1080x764 = Size(width: 1080, height: 764)
-// => Size
+// returns Size
 var size1200x800 = size1080x764
-// => Size
+// returns Size
 size1200x800.resize(newWidth: 1200, newHeight: 800)
 size1200x800.height
-// => 800
+// returns 800
 ```
 
 ## 2. Define a Position struct
@@ -46,10 +46,10 @@ Include a method `moveTo(newX:newY:)` that takes new x and y parameters and chan
 
 ```swift
 var point = Position(x: 10, y: 20)
-// => Position
+// returns Position
 point.moveTo(newX: 100, newY: -100)
 point.y
-// => -100
+// returns -100
 ```
 
 ## 3. Define a Window class
@@ -61,6 +61,14 @@ Define a window class with the following properties:
 - `size` : `Size`, initial value is the default value of the `Size` struct
 - `position` : `Position`, initial value is the default value of the `Position` struct
 - `contents` : `String?`, initial value is `nil`
+
+You should also define an empty initializer for the class.
+
+```swift
+let window = Window()
+window.display()
+// returns "New Window\nPosition: (0, 0), Size: (80 x 60)\n[This window intentionally left blank]"
+```
 
 ## 4. Add a method to resize windows
 
@@ -76,8 +84,19 @@ Define a window class with the following properties:
 - `update(text:)` : `(String?) -> ()` - This method sets the `contents` property to the value of the optional string that was passed in.
 - `display()` : `() -> String` - This method returns a string describing the current state of the window. For example, if the window has the `title` "My First Window" with position: x = 10, y = 100; size: width = 200, height = 150; and contents: "I 😍 my window", it should return the string: `"My First Window\nPosition: (10, 100), Size: (200 x 150)\nI 😍 my window\n"` - If `contents` is nil, the last line should read "[This window intentionally left blank]"
 
-## 7. Create a new Window
+## 7. Create an initilazer for the Window class
 
-Create an instances of the Window class and modify it via their methods as follows:
+The window system should have an initializer so the that the window can be created with custom inputs.
+Create **another** initializer for the `Window` class.
+The initializer should take the following parameters: `title`, `contents`, and two optional parameters `size` and `position`.
+The `size` and `position` parameters should default to the default values of the `Size` and `Position` structs.
 
-- The window should be given the title "Main Window", with a width of 400, a height of 300 and positioned at x = 100, y = 100. Its contents should be "This is the main window". Assign this instance to the name `mainWindow`.
+```swift
+let window = Window(title: "My First Window", contents: "I 😍 my window")
+window.display()
+// returns "My First Window\nPosition: (0, 0), Size: (80 x 60)\nI 😍 my window\n"
+
+let window2 = Window(title: "My Second Window", contents: "I 😍 my window", size: Size(width: 200, height: 150), position: Position(x: 10, y: 100))
+window2.display()
+// returns "My Second Window\nPosition: (10, 100), Size: (200 x 150)\nI 😍 my window\n"
+```

--- a/exercises/concept/windowing-system/.meta/Sources/WindowingSystem/WindowingSystemExemplar.swift
+++ b/exercises/concept/windowing-system/.meta/Sources/WindowingSystem/WindowingSystemExemplar.swift
@@ -18,12 +18,21 @@ struct Size {
   }
 }
 
-class Window: @unchecked Sendable  {
+class Window {
   var title = "New Window"
   let screenSize = Size(width: 800, height: 600)
   var size = Size()
   var position = Position()
   var contents: String?
+
+  init() {}
+
+  init(title: String, contents: String?, size : Size = Size(), position: Position = Position()) {
+    self.title = title
+    self.contents = contents
+    self.size = size
+    self.position = position
+  }
 
   func move(to newPosition: Position) {
     let minX = min(max(0, newPosition.x), screenSize.width - size.width)
@@ -45,12 +54,3 @@ class Window: @unchecked Sendable  {
     "\(title)\nPosition: (\(position.x), \(position.y)), Size: (\(size.width) x \(size.height))\n\(contents ?? "[This window intentionally left blank]")\n"
   }
 }
-
-let mainWindow: Window = {
-  var window = Window()
-  window.title = "Main Window"
-  window.contents = "This is the main window"
-  window.move(to: Position(x: 100, y: 100))
-  window.resize(to: Size(width: 400, height: 300))
-  return window
-}()

--- a/exercises/concept/windowing-system/.meta/config.json
+++ b/exercises/concept/windowing-system/.meta/config.json
@@ -2,6 +2,9 @@
   "authors": [
     "wneumann"
   ],
+  "contributors": [
+    "meatball133"
+  ],
   "files": {
     "solution": [
       "Sources/WindowingSystem/WindowingSystem.swift"

--- a/exercises/concept/windowing-system/Package.swift
+++ b/exercises/concept/windowing-system/Package.swift
@@ -1,28 +1,28 @@
-// swift-tools-version:5.3
+// swift-tools-version:6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
-    name: "WindowingSystem",
-    products: [
-        // Products define the executables and libraries a package produces, and make them visible to other packages.
-        .library(
-            name: "WindowingSystem",
-            targets: ["WindowingSystem"]),
-    ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
-    targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages this package depends on.
-        .target(
-            name: "WindowingSystem",
-            dependencies: []),
-        .testTarget(
-            name: "WindowingSystemTests",
-            dependencies: ["WindowingSystem"]),
-    ]
+  name: "WindowingSystem",
+  products: [
+    // Products define the executables and libraries a package produces, and make them visible to other packages.
+    .library(
+      name: "WindowingSystem",
+      targets: ["WindowingSystem"])
+  ],
+  dependencies: [
+    // Dependencies declare other packages that this package depends on.
+    // .package(url: /* package url */, from: "1.0.0"),
+  ],
+  targets: [
+    // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+    // Targets can depend on other targets in this package, and on products in packages this package depends on.
+    .target(
+      name: "WindowingSystem",
+      dependencies: []),
+    .testTarget(
+      name: "WindowingSystemTests",
+      dependencies: ["WindowingSystem"]),
+  ]
 )

--- a/exercises/concept/windowing-system/Tests/WindowingSystemTests/WindowingSystemTests.swift
+++ b/exercises/concept/windowing-system/Tests/WindowingSystemTests/WindowingSystemTests.swift
@@ -1,161 +1,166 @@
-import XCTest
+import FoundationEssentials
+import Testing
 
 @testable import WindowingSystem
 
-final class WindowingSystemTests: XCTestCase {
-  let runAll = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"]) ?? false
+let RUNALL = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"]) ?? false
 
+@Suite struct WindowingSystemTests {
+  @Test("New Window")
   func testNewWindow() {
-    // This is an example of a functional test case.
-    // Use XCTAssert and related functions to verify your tests produce the correct
-    // results.
-    XCTAssertEqual(
-      Window().display(),
-      "New Window\nPosition: (0, 0), Size: (80 x 60)\n[This window intentionally left blank]\n")
+    #expect(
+      Window().display()
+        == "New Window\nPosition: (0, 0), Size: (80 x 60)\n[This window intentionally left blank]\n"
+    )
   }
 
-  func testMainWindow() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    XCTAssertEqual(
-      mainWindow.display(),
-      "Main Window\nPosition: (100, 100), Size: (400 x 300)\nThis is the main window\n")
-  }
-
-  func testPositionMove() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Position Move", .enabled(if: RUNALL))
+  func testPositionMove() {
     var pos = Position()
     let newX = Int.random(in: 0...100)
     let newY = Int.random(in: 0...1000)
     pos.moveTo(newX: newX, newY: newY)
-    XCTAssertTrue(
+    #expect(
       pos.x == newX && pos.y == newY,
       "Expected: Position(x: \(newX), \(newY)), got Position(x: \(pos.x), \(pos.y))")
   }
 
-  func testResize() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Size Resize", .enabled(if: RUNALL))
+  func testSizeResize() {
     var size = Size()
     let newWidth = Int.random(in: 0...100)
     let newHeight = Int.random(in: 0...1000)
     size.resize(newWidth: newWidth, newHeight: newHeight)
-    XCTAssertTrue(
+    #expect(
       size.width == newWidth && size.height == newHeight,
-      "Expected: Size(width: \(newWidth), height: \(newHeight)), got Size(width: \(size.width), height: \(size.height))")
+      "Expected: Size(width: \(newWidth), height: \(newHeight)), got Size(width: \(size.width), height: \(size.height))"
+    )
   }
 
-  func testMoveValid() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let testWindow: Window = {
-      let window = Window()
-      window.title = "Test Window"
-      window.contents = "test"
-      window.resize(to: Size(width: 100, height: 100))
-      window.move(to: Position(x: 100, y: 100))
-      return window
-    }()
-    XCTAssertEqual(
-      testWindow.display(),
-      "Test Window\nPosition: (100, 100), Size: (100 x 100)\ntest\n")
+  @Test("Move Valid", .enabled(if: RUNALL))
+  func testMoveValid() {
+    let testWindow = Window()
+    testWindow.title = "Test Window"
+    testWindow.contents = "test"
+    testWindow.resize(to: Size(width: 100, height: 100))
+    testWindow.move(to: Position(x: 100, y: 100))
+    #expect(testWindow.display() == "Test Window\nPosition: (100, 100), Size: (100 x 100)\ntest\n")
   }
 
-  func testMoveTooFar() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let testWindow: Window = {
-      let window = Window()
-      window.title = "Test Window"
-      window.contents = "test"
-      window.resize(to: Size(width: 100, height: 100))
-      window.move(to: Position(x: 750, y: 650))
-      return window
-    }()
-    XCTAssertEqual(
-      testWindow.display(),
-      "Test Window\nPosition: (700, 500), Size: (100 x 100)\ntest\n")
+  @Test("Move Too Far", .enabled(if: RUNALL))
+  func testMoveTooFar() {
+    let testWindow = Window()
+    testWindow.title = "Test Window"
+    testWindow.contents = "test"
+    testWindow.resize(to: Size(width: 100, height: 100))
+    testWindow.move(to: Position(x: 750, y: 650))
+    #expect(testWindow.display() == "Test Window\nPosition: (700, 500), Size: (100 x 100)\ntest\n")
   }
 
-  func testMoveNegative() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let testWindow: Window = {
-      let window = Window()
-      window.title = "Test Window"
-      window.contents = "test"
-      window.resize(to: Size(width: 100, height: 100))
-      window.move(to: Position(x: -80, y: -60))
-      return window
-    }()
-    XCTAssertEqual(
-      testWindow.display(),
-      "Test Window\nPosition: (0, 0), Size: (100 x 100)\ntest\n")
+  @Test("Move Negative", .enabled(if: RUNALL))
+  func testMoveNegative() {
+    let testWindow = Window()
+    testWindow.title = "Test Window"
+    testWindow.contents = "test"
+    testWindow.resize(to: Size(width: 100, height: 100))
+    testWindow.move(to: Position(x: -80, y: -60))
+    #expect(testWindow.display() == "Test Window\nPosition: (0, 0), Size: (100 x 100)\ntest\n")
   }
 
-  func testResizeValid() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let testWindow: Window = {
-      let window = Window()
-      window.title = "Test Window"
-      window.contents = "test"
-      window.move(to: Position(x: 600, y: 500))
-      window.resize(to: Size(width: 100, height: 100))
-      return window
-    }()
-    XCTAssertEqual(
-      testWindow.display(),
-      "Test Window\nPosition: (600, 500), Size: (100 x 100)\ntest\n")
+  @Test("Resize Valid", .enabled(if: RUNALL))
+  func testResizeValid() {
+    let testWindow = Window()
+    testWindow.title = "Test Window"
+    testWindow.contents = "test"
+    testWindow.move(to: Position(x: 600, y: 500))
+    testWindow.resize(to: Size(width: 100, height: 100))
+    #expect(testWindow.display() == "Test Window\nPosition: (600, 500), Size: (100 x 100)\ntest\n")
   }
 
-  func testResizeTooFar() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let testWindow: Window = {
-      let window = Window()
-      window.title = "Test Window"
-      window.contents = "test"
-      window.move(to: Position(x: 710, y: 525))
-      window.resize(to: Size(width: 1000, height: 1000))
-      return window
-    }()
-    XCTAssertEqual(
-      testWindow.display(),
-      "Test Window\nPosition: (710, 525), Size: (90 x 75)\ntest\n")
+  @Test("Resize Too Far", .enabled(if: RUNALL))
+  func testResizeTooFar() {
+    let testWindow = Window()
+    testWindow.title = "Test Window"
+    testWindow.contents = "test"
+    testWindow.move(to: Position(x: 710, y: 525))
+    testWindow.resize(to: Size(width: 1000, height: 1000))
+    #expect(testWindow.display() == "Test Window\nPosition: (710, 525), Size: (90 x 75)\ntest\n")
   }
 
-  func testResizeNegative() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let testWindow: Window = {
-      let window = Window()
-      window.title = "Test Window"
-      window.contents = "test"
-      window.resize(to: Size(width: 0, height: -100))
-      return window
-    }()
-    XCTAssertEqual(
-      testWindow.display(),
-      "Test Window\nPosition: (0, 0), Size: (1 x 1)\ntest\n")
+  @Test("Resize Negative", .enabled(if: RUNALL))
+  func testResizeNegative() {
+    let testWindow = Window()
+    testWindow.title = "Test Window"
+    testWindow.contents = "test"
+    testWindow.resize(to: Size(width: 0, height: -100))
+    #expect(testWindow.display() == "Test Window\nPosition: (0, 0), Size: (1 x 1)\ntest\n")
   }
 
-  func testUpdateTitle() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Update Title", .enabled(if: RUNALL))
+  func testUpdateTitle() {
     let window = Window()
     window.update(title: "Did it change?")
-    XCTAssertEqual(
-      window.display(),
-      "Did it change?\nPosition: (0, 0), Size: (80 x 60)\n[This window intentionally left blank]\n")
+    #expect(
+      window.display()
+        == "Did it change?\nPosition: (0, 0), Size: (80 x 60)\n[This window intentionally left blank]\n"
+    )
   }
 
-  func testUpdateText() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Update Text", .enabled(if: RUNALL))
+  func testUpdateText() {
     let window = Window()
     window.update(text: "Did it change?")
-    XCTAssertEqual(
-      window.display(), "New Window\nPosition: (0, 0), Size: (80 x 60)\nDid it change?\n")
+    #expect(window.display() == "New Window\nPosition: (0, 0), Size: (80 x 60)\nDid it change?\n")
   }
 
-  func testUpdateTextNil() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("Update Text Nil", .enabled(if: RUNALL))
+  func testUpdateTextNil() {
     let window = Window()
     window.update(text: "Did it change?")
     window.update(text: nil)
-    XCTAssertEqual(
-      window.display(),
-      "New Window\nPosition: (0, 0), Size: (80 x 60)\n[This window intentionally left blank]\n")
+    #expect(
+      window.display()
+        == "New Window\nPosition: (0, 0), Size: (80 x 60)\n[This window intentionally left blank]\n"
+    )
+  }
+
+  @Test("Initialzer accepts all input", .enabled(if: RUNALL))
+  func testMainWindow() {
+    let window = Window(title: "Main Window", contents: "This is the main window", size: Size(width: 400, height: 300), position: Position(x: 100, y: 100))
+    #expect(
+      window.display()
+        == "Main Window\nPosition: (100, 100), Size: (400 x 300)\nThis is the main window\n")
+  }
+
+  @Test("Initialzer accepts all input except contents", .enabled(if: RUNALL))
+  func testMainWindowNoContents() {
+    let window = Window(title: "Main Window", contents: nil, size: Size(width: 400, height: 300), position: Position(x: 100, y: 100))
+    #expect(
+      window.display()
+        == "Main Window\nPosition: (100, 100), Size: (400 x 300)\n[This window intentionally left blank]\n")
+  }
+
+  @Test("Initialzer accepts all input except size", .enabled(if: RUNALL))
+  func testMainWindowNoSize() {
+    let window = Window(title: "Main Window", contents: "This is the main window", size: Size(), position: Position(x: 100, y: 100))
+    #expect(
+      window.display()
+        == "Main Window\nPosition: (100, 100), Size: (80 x 60)\nThis is the main window\n")
+  }
+
+  @Test("Initialzer accepts all input except position", .enabled(if: RUNALL))
+  func testMainWindowNoPosition() {
+    let window = Window(title: "Main Window", contents: "This is the main window", size: Size(width: 400, height: 300), position: Position())
+    #expect(
+      window.display()
+        == "Main Window\nPosition: (0, 0), Size: (400 x 300)\nThis is the main window\n")
+  }
+
+  @Test("Initialzer accepts no position and no size", .enabled(if: RUNALL))
+  func testMainWindowNoPositionNoSize() {
+    let window = Window(title: "Main Window", contents: "This is the main window")
+    #expect(
+      window.display()
+        == "Main Window\nPosition: (0, 0), Size: (80 x 60)\nThis is the main window\n")
   }
 }


### PR DESCRIPTION
resolves #746

This removes the old closure task of the exercise, as far as I can tell is it deemed unsafe in Swift 6, and there has been several complaints about that task anyway. It is being replaced by a new initializer task instead (which is likely quite relevant to classes and struct). 

TODO:

- Add proper hints file
- Update concept files to include info about initializer. 