### PR TITLE
Swift-Numerics try to improve preformance

### DIFF
--- a/exercises/concept/freelancer-rates/Package.swift
+++ b/exercises/concept/freelancer-rates/Package.swift
@@ -24,6 +24,6 @@ let package = Package(
       dependencies: []),
     .testTarget(
       name: "FreelancerRatesTests",
-      dependencies: ["FreelancerRates", .product(name: "Numerics", package: "swift-numerics"),]),
+      dependencies: ["FreelancerRates", .product(name: "RealModule", package: "swift-numerics"),]),
   ]
 )

--- a/exercises/concept/freelancer-rates/Tests/FreelancerRatesTests/FreelancerRatesTests.swift
+++ b/exercises/concept/freelancer-rates/Tests/FreelancerRatesTests/FreelancerRatesTests.swift
@@ -1,6 +1,6 @@
 import Testing
 import Foundation
-import Numerics
+import RealModule
 
 @testable import FreelancerRates
 

--- a/exercises/concept/lasagna-master/Package.swift
+++ b/exercises/concept/lasagna-master/Package.swift
@@ -24,6 +24,6 @@ let package = Package(
             dependencies: []),
         .testTarget(
             name: "LasagnaMasterTests",
-            dependencies: ["LasagnaMaster", .product(name: "Numerics", package: "swift-numerics")]),
+            dependencies: ["LasagnaMaster", .product(name: "RealModule", package: "swift-numerics")]),
     ]
 )

--- a/exercises/concept/lasagna-master/Tests/LasagnaMasterTests/LasagnaMasterTests.swift
+++ b/exercises/concept/lasagna-master/Tests/LasagnaMasterTests/LasagnaMasterTests.swift
@@ -1,6 +1,6 @@
 import Testing
 import Foundation
-import Numerics
+import RealModule
 
 @testable import LasagnaMaster
 

--- a/exercises/concept/pizza-slices/Package.swift
+++ b/exercises/concept/pizza-slices/Package.swift
@@ -24,6 +24,6 @@ let package = Package(
       dependencies: []),
     .testTarget(
       name: "PizzaSlicesTests",
-      dependencies: ["PizzaSlices", .product(name: "Numerics", package: "swift-numerics"),]),
+      dependencies: ["PizzaSlices", .product(name: "RealModule", package: "swift-numerics"),]),
   ]
 )

--- a/exercises/concept/pizza-slices/Tests/PizzaSlicesTests/PizzaSlicesTests.swift
+++ b/exercises/concept/pizza-slices/Tests/PizzaSlicesTests/PizzaSlicesTests.swift
@@ -1,6 +1,6 @@
 import Testing
 import Foundation
-import Numerics
+import RealModule
 
 @testable import PizzaSlices
 

--- a/exercises/practice/complex-numbers/.docs/instructions.append.md
+++ b/exercises/practice/complex-numbers/.docs/instructions.append.md
@@ -3,6 +3,8 @@
 You will have to implement your own equality operator for the `ComplexNumber` object.
 This will pose the challenge of comparing two floating point numbers.
 It might be useful to use the method `isApproximatelyEqual(to:absoluteTolerance:)` which can be found in the [Numerics][swift-numberics] library.
+Due to preformance issues will you only have access to the `RealModule` part.
+To import it simply write: `import RealModule` at the top of the file.
 A given tolerance of `0.00001` should be enough to pass the tests.
 The library is already imported in the project so it is just to import it in your file.
 

--- a/exercises/practice/complex-numbers/.meta/Sources/ComplexNumbers/ComplexNumbersExample.swift
+++ b/exercises/practice/complex-numbers/.meta/Sources/ComplexNumbers/ComplexNumbersExample.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Numerics
+import RealModule
 
 struct ComplexNumbers: Equatable {
 

--- a/exercises/practice/complex-numbers/Package.swift
+++ b/exercises/practice/complex-numbers/Package.swift
@@ -16,13 +16,12 @@ let package = Package(
     .target(
       name: "ComplexNumbers",
       dependencies: [
-        .product(name: "Numerics", package: "swift-numerics")
+        .product(name: "RealModule", package: "swift-numerics")
       ]),
     .testTarget(
       name: "ComplexNumbersTests",
       dependencies: [
-        "ComplexNumbers",
-        .product(name: "Numerics", package: "swift-numerics"),
+        "ComplexNumbers"
       ]),
   ]
 )

--- a/exercises/practice/space-age/.meta/template.swift
+++ b/exercises/practice/space-age/.meta/template.swift
@@ -1,6 +1,6 @@
 import Testing
 import Foundation
-import Numerics
+import RealModule
 @testable import {{exercise|camelCase}}
 
 let RUNALL = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"]) ?? false

--- a/exercises/practice/space-age/Package.swift
+++ b/exercises/practice/space-age/Package.swift
@@ -14,10 +14,9 @@ let package = Package(
   ],
   targets: [
     .target(
-      name: "SpaceAge",
-      dependencies: [.product(name: "Numerics", package: "swift-numerics")]),
+      name: "SpaceAge"
     .testTarget(
       name: "SpaceAgeTests",
-      dependencies: [.product(name: "Numerics", package: "swift-numerics"), "SpaceAge"]),
+      dependencies: [.product(name: "RealModule", package: "swift-numerics"), "SpaceAge"]),
   ]
 )

--- a/exercises/practice/space-age/Tests/SpaceAgeTests/SpaceAgeTests.swift
+++ b/exercises/practice/space-age/Tests/SpaceAgeTests/SpaceAgeTests.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Numerics
+import RealModule
 import Testing
 
 @testable import SpaceAge


### PR DESCRIPTION
While doing preformance tests: https://github.com/exercism/swift-test-runner/pull/59
I did both some optimzation on the test runners logic itself but I also found that the library needed could be made smaller. This is a pr to test if that could make the preformance to an acceptable level.