### PR TITLE
Remove plarform specific imports

### DIFF
--- a/exercises/practice/octal/.meta/Sources/Octal/OctalExample.swift
+++ b/exercises/practice/octal/.meta/Sources/Octal/OctalExample.swift
@@ -1,8 +1,4 @@
-#if os(Linux)
-    import Glibc
-#elseif os(OSX)
-    import Darwin
-#endif
+import Foundation
 
 extension Int {
 

--- a/exercises/practice/robot-name/.meta/Sources/RobotName/RobotNameExample.swift
+++ b/exercises/practice/robot-name/.meta/Sources/RobotName/RobotNameExample.swift
@@ -1,20 +1,15 @@
-#if os(Linux)
-  import Glibc
-#elseif os(OSX)
-  import Darwin
-  let random = arc4random
-#endif
+import Foundation
 
 struct Robot {
   var name: String
 
   init() {
-    let numberPart = (Int(random()) % 899) + 100
+    let numberPart = (Int.random(in: 0..<899)) + 100
     name = generateRandomLetter() + generateRandomLetter() + "\(numberPart)"
   }
 
   mutating func resetName() {
-    let numberPart = (Int(random()) % 899) + 100
+    let numberPart = (Int.random(in: 0..<899)) + 100
     name = generateRandomLetter() + generateRandomLetter() + "\(numberPart)"
   }
 }
@@ -30,6 +25,6 @@ private func convertStringToStringArray(_ input: String) -> [String] {
 private func generateRandomLetter() -> String {
   let alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
   let letters = convertStringToStringArray(alphabet)
-  let randomIndex = Int(random()) % letters.count
+  let randomIndex = Int.random(in: 0..<letters.count)
   return letters[randomIndex]
 }

--- a/exercises/practice/simple-cipher/.meta/Sources/SimpleCipher/SimpleCipherExample.swift
+++ b/exercises/practice/simple-cipher/.meta/Sources/SimpleCipher/SimpleCipherExample.swift
@@ -1,20 +1,5 @@
 import Foundation
 
-#if os(Linux)
-  import Glibc
-#elseif os(OSX)
-  import Darwin
-#endif
-
-func arc4random_uniform(_ input: Int) -> Int {
-  #if os(Linux)
-    return random() % input
-  #elseif os(OSX)
-    let temp = UInt32(input)
-    return Int(arc4random_uniform(temp))
-  #endif
-}
-
 public struct Cipher {
   private let abc = "abcdefghijklmnopqrstuvwxyz"
   private var alphabet: [Character] { return Array(abc) }
@@ -23,7 +8,7 @@ public struct Cipher {
   private func randomKeySet() -> String {
     var tempKey = ""
     for _ in (0..<100).enumerated() {
-      tempKey.append(alphabet[arc4random_uniform(alphabet.count)])
+      tempKey.append(alphabet[Int.random(in: 0..<alphabet.count)])
     }
     return tempKey
   }

--- a/exercises/practice/trinary/.meta/Sources/Trinary/TrinaryExample.swift
+++ b/exercises/practice/trinary/.meta/Sources/Trinary/TrinaryExample.swift
@@ -1,8 +1,4 @@
-#if os(Linux)
-    import Glibc
-#elseif os(OSX)
-    import Darwin
-#endif
+import Foundation
 
 extension Int {
     init(_ value: Trinary) {


### PR DESCRIPTION
#### What is the problem?

Building for Windows environment with `swift build` or `swift test` will fail due to missing imports.

#### Proposed changes

The changed files are old, from a time when modern and simple APIs were not yet available. Now everything is possible with Foundation. This minor changes allow to build and test the whole swift track.