### PR TITLE
Rewrite test template for Queen-Attack practise exercise to wotk with Swift Testing

### DIFF
--- a/exercises/practice/queen-attack/.meta/template.swift
+++ b/exercises/practice/queen-attack/.meta/template.swift
@@ -1,38 +1,45 @@
-import XCTest
-@testable import {{exercise|camelCase}}
-class {{exercise|camelCase}}Tests: XCTestCase {
-    let runAll = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"]) ?? false
+import Testing
+import Foundation
+@testable import {{exercise | camelCase}}
 
+let RUNALL = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"]) ?? false
+
+@Suite struct {{exercise | camelCase}}Tests {
     {% outer: for case in cases %}
         {%- for subCases in case.cases %}
         {%- if forloop.outer.first and forloop.first %}
-            func test{{subCases.description |camelCase }}() {
+            @Test("{{subCases.description}}")
         {%- else %}
-            func test{{subCases.description |camelCase }}() throws {
-            try XCTSkipIf(true && !runAll) // change true to false to run this test
+            @Test("{{subCases.description}}", .enabled(if: RUNALL))
         {%- endif %}
+            func test{{subCases.description | camelCase}}() throws {
         {%- if subCases.property == "create" %}
             {%- if subCases.expected.error %}
-                XCTAssertThrowsError(try Queen(row: {{subCases.input.queen.position.row}}, column: {{subCases.input.queen.position.column}})) { error in
-                    {%- if subCases.expected.error | contains:"row"  %}
-                    XCTAssertEqual(error as? QueenError, .inValidRow)
-                    {%- else %}
-                    XCTAssertEqual(error as? QueenError, .inValidColumn)
-                    {%- endif %}
+                {%- if subCases.expected.error | contains: "row" %}
+                #expect(throws: QueenError.inValidRow)
+                {%- else %}
+                #expect(throws: QueenError.inValidColumn)
+                {%- endif %}
+                {
+                    try Queen(row: {{subCases.input.queen.position.row}}, column: {{subCases.input.queen.position.column}})
                 }
             {%- else %}
-                let queen = try! Queen(row: {{subCases.input.queen.position.row}}, column: {{subCases.input.queen.position.column}})
-                XCTAssertEqual(queen.row, {{subCases.input.queen.position.row}})
-                XCTAssertEqual(queen.column, {{subCases.input.queen.position.column}})
+                #expect(throws: Never.self) {
+                    let queen = try Queen(row: {{subCases.input.queen.position.row}}, column: {{subCases.input.queen.position.column}})
+                    #expect(queen.row == {{subCases.input.queen.position.row}})
+                    #expect(queen.column == {{subCases.input.queen.position.column}})
+                }
             {%- endif %}
         {%- else %}
-            let queen = try! Queen(row: {{subCases.input.white_queen.position.row}}, column: {{subCases.input.white_queen.position.column}})
-            let otherQueen = try! Queen(row: {{subCases.input.black_queen.position.row}}, column: {{subCases.input.black_queen.position.column}})
+            #expect(throws: Never.self) {
+                let queen = try Queen(row: {{subCases.input.white_queen.position.row}}, column: {{subCases.input.white_queen.position.column}})
+                let otherQueen = try Queen(row: {{subCases.input.black_queen.position.row}}, column: {{subCases.input.black_queen.position.column}})
             {%- if subCases.expected %}
-                XCTAssertTrue(queen.canAttack(other: otherQueen))
+                #expect(queen.canAttack(other: otherQueen))
             {%- else %}
-                XCTAssertFalse(queen.canAttack(other: otherQueen))
+                #expect(!queen.canAttack(other: otherQueen))
             {%- endif %}
+            }
         {%- endif %}
         }
         {% endfor -%}

--- a/exercises/practice/queen-attack/Tests/QueenAttackTests/QueenAttackTests.swift
+++ b/exercises/practice/queen-attack/Tests/QueenAttackTests/QueenAttackTests.swift
@@ -1,100 +1,123 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import QueenAttack
 
-class QueenAttackTests: XCTestCase {
-  let runAll = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"]) ?? false
+let RUNALL = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"]) ?? false
 
-  func testQueenWithAValidPosition() {
-    let queen = try! Queen(row: 2, column: 2)
-    XCTAssertEqual(queen.row, 2)
-    XCTAssertEqual(queen.column, 2)
+@Suite struct QueenAttackTests {
+
+  @Test("queen with a valid position")
+  func testQueenWithAValidPosition() throws {
+    #expect(throws: Never.self) {
+      let queen = try Queen(row: 2, column: 2)
+      #expect(queen.row == 2)
+      #expect(queen.column == 2)
+    }
   }
 
+  @Test("queen must have positive row", .enabled(if: RUNALL))
   func testQueenMustHavePositiveRow() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    XCTAssertThrowsError(try Queen(row: -2, column: 2)) { error in
-      XCTAssertEqual(error as? QueenError, .inValidRow)
+    #expect(throws: QueenError.inValidRow) {
+      try Queen(row: -2, column: 2)
     }
   }
 
+  @Test("queen must have row on board", .enabled(if: RUNALL))
   func testQueenMustHaveRowOnBoard() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    XCTAssertThrowsError(try Queen(row: 8, column: 4)) { error in
-      XCTAssertEqual(error as? QueenError, .inValidRow)
+    #expect(throws: QueenError.inValidRow) {
+      try Queen(row: 8, column: 4)
     }
   }
 
+  @Test("queen must have positive column", .enabled(if: RUNALL))
   func testQueenMustHavePositiveColumn() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    XCTAssertThrowsError(try Queen(row: 2, column: -2)) { error in
-      XCTAssertEqual(error as? QueenError, .inValidColumn)
+    #expect(throws: QueenError.inValidColumn) {
+      try Queen(row: 2, column: -2)
     }
   }
 
+  @Test("queen must have column on board", .enabled(if: RUNALL))
   func testQueenMustHaveColumnOnBoard() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    XCTAssertThrowsError(try Queen(row: 4, column: 8)) { error in
-      XCTAssertEqual(error as? QueenError, .inValidColumn)
+    #expect(throws: QueenError.inValidColumn) {
+      try Queen(row: 4, column: 8)
     }
   }
 
+  @Test("cannot attack", .enabled(if: RUNALL))
   func testCannotAttack() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let queen = try! Queen(row: 2, column: 4)
-    let otherQueen = try! Queen(row: 6, column: 6)
-    XCTAssertFalse(queen.canAttack(other: otherQueen))
+    #expect(throws: Never.self) {
+      let queen = try Queen(row: 2, column: 4)
+      let otherQueen = try Queen(row: 6, column: 6)
+      #expect(!queen.canAttack(other: otherQueen))
+    }
   }
 
+  @Test("can attack on same row", .enabled(if: RUNALL))
   func testCanAttackOnSameRow() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let queen = try! Queen(row: 2, column: 4)
-    let otherQueen = try! Queen(row: 2, column: 6)
-    XCTAssertTrue(queen.canAttack(other: otherQueen))
+    #expect(throws: Never.self) {
+      let queen = try Queen(row: 2, column: 4)
+      let otherQueen = try Queen(row: 2, column: 6)
+      #expect(queen.canAttack(other: otherQueen))
+    }
   }
 
+  @Test("can attack on same column", .enabled(if: RUNALL))
   func testCanAttackOnSameColumn() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let queen = try! Queen(row: 4, column: 5)
-    let otherQueen = try! Queen(row: 2, column: 5)
-    XCTAssertTrue(queen.canAttack(other: otherQueen))
+    #expect(throws: Never.self) {
+      let queen = try Queen(row: 4, column: 5)
+      let otherQueen = try Queen(row: 2, column: 5)
+      #expect(queen.canAttack(other: otherQueen))
+    }
   }
 
+  @Test("can attack on first diagonal", .enabled(if: RUNALL))
   func testCanAttackOnFirstDiagonal() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let queen = try! Queen(row: 2, column: 2)
-    let otherQueen = try! Queen(row: 0, column: 4)
-    XCTAssertTrue(queen.canAttack(other: otherQueen))
+    #expect(throws: Never.self) {
+      let queen = try Queen(row: 2, column: 2)
+      let otherQueen = try Queen(row: 0, column: 4)
+      #expect(queen.canAttack(other: otherQueen))
+    }
   }
 
+  @Test("can attack on second diagonal", .enabled(if: RUNALL))
   func testCanAttackOnSecondDiagonal() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let queen = try! Queen(row: 2, column: 2)
-    let otherQueen = try! Queen(row: 3, column: 1)
-    XCTAssertTrue(queen.canAttack(other: otherQueen))
+    #expect(throws: Never.self) {
+      let queen = try Queen(row: 2, column: 2)
+      let otherQueen = try Queen(row: 3, column: 1)
+      #expect(queen.canAttack(other: otherQueen))
+    }
   }
 
+  @Test("can attack on third diagonal", .enabled(if: RUNALL))
   func testCanAttackOnThirdDiagonal() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let queen = try! Queen(row: 2, column: 2)
-    let otherQueen = try! Queen(row: 1, column: 1)
-    XCTAssertTrue(queen.canAttack(other: otherQueen))
+    #expect(throws: Never.self) {
+      let queen = try Queen(row: 2, column: 2)
+      let otherQueen = try Queen(row: 1, column: 1)
+      #expect(queen.canAttack(other: otherQueen))
+    }
   }
 
+  @Test("can attack on fourth diagonal", .enabled(if: RUNALL))
   func testCanAttackOnFourthDiagonal() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let queen = try! Queen(row: 1, column: 7)
-    let otherQueen = try! Queen(row: 0, column: 6)
-    XCTAssertTrue(queen.canAttack(other: otherQueen))
+    #expect(throws: Never.self) {
+      let queen = try Queen(row: 1, column: 7)
+      let otherQueen = try Queen(row: 0, column: 6)
+      #expect(queen.canAttack(other: otherQueen))
+    }
   }
 
+  @Test(
+    "cannot attack if falling diagonals are only the same when reflected across the longest falling diagonal",
+    .enabled(if: RUNALL))
   func
     testCannotAttackIfFallingDiagonalsAreOnlyTheSameWhenReflectedAcrossTheLongestFallingDiagonal()
     throws
   {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let queen = try! Queen(row: 4, column: 1)
-    let otherQueen = try! Queen(row: 2, column: 5)
-    XCTAssertFalse(queen.canAttack(other: otherQueen))
+    #expect(throws: Never.self) {
+      let queen = try Queen(row: 4, column: 1)
+      let otherQueen = try Queen(row: 2, column: 5)
+      #expect(!queen.canAttack(other: otherQueen))
+    }
   }
 }


### PR DESCRIPTION
## What is the problem?
During [the mentoring session](https://exercism.org/mentoring/discussions/67db264d34554cc795402ca295072b18) I've figured out that there is a problem with running tests in CI for [Queen Attack](https://github.com/exercism/swift/tree/main/exercises/practice/queen-attack) exercise.

Looks like test are passing, but for some reason test results are not passed to external artifacts.

```
Build complete! (11.16s)
Test Suite 'All tests' started at 2025-06-18 19:55:45.422
Test Suite 'debug.xctest' started at 2025-06-18 19:55:45.423
Test Suite 'QueenAttackTests' started at 2025-06-18 19:55:45.423
Test Case 'QueenAttackTests.testCanAttackOnFirstDiagonal' started at 2025-06-18 19:55:45.423
...
...
19:55:45.525	 Executed 13 tests, with 0 failures (0 unexpected) in 0.102 (0.102) seconds
Test Suite 'debug.xctest' passed at 2025-06-18 19:55:45.525	Executed 13 tests, with 0 failures (0 unexpected) in 0.102 (0.102) seconds
Test Suite 'All tests' passed at 2025-06-18 19:55:45.526 Executed 13 tests, with 0 failures (0 unexpected) in 0.102 (0.102) seconds◇ 
Test run started.
Testing Library Version: 6.1.2 (d6b70f9ef9eb207)
Target Platform: x86_64-unknown-linux-gnu✔ 
Test run with 0 tests passed after 0.001 seconds.
```

The possible problem is [discussed here](https://github.com/swiftlang/swift-package-manager/issues/8529). TLDR; Separate test drivers for XCTest and Swift Testing, cannot be summarized in the same report.

## Proposed Solution
Rewrite to Swift Testing and forget about XCTest.
