### PR TITLE
Remove Ubuntu from CI workflow, using only macOS for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-15]
+        os: [macos-15]
         swift: ["6.0", "6.1"]
     env:
       RUNALL: "true"


### PR DESCRIPTION
Due to the Ubuntu ci have a tendency to fail (this is due to a dependency which has this as known issue). It is intended to be solved with the next version which seems to be stalled atm. So I decide to disable them for now.