### PR TITLE
Fixed minor formatting issue in introduction.md

### DIFF
--- a/exercises/concept/lasagna-master/.docs/introduction.md
+++ b/exercises/concept/lasagna-master/.docs/introduction.md
@@ -65,7 +65,6 @@ updateVersion(&dbRecord)
 // dbRecord is now (3, "Exercism")
 ```
 
-~~~~exercism/warrning
 There are a couple of extra rules one should be aware of regarding in-out parameters.
 
 1.  Inside a function with in-out parameters, you are not allowed to reference the variable that was passed in as the in-out parameter.
@@ -81,7 +80,7 @@ var mutVar = 0
 inoutFunc(&mutVar, &mutVar)
 // raises a compiler error: "Inout arguments are not allowed to alias each other"
 ```
-~~~~
+
 
 ## Nested functions
 


### PR DESCRIPTION
While using Exercism for practice found that the \`\`\`swift ... \`\`\` is visible in the introduction guide, which I thought is due to a formatting issue caused due to the surrounding tag ~~~~exercism/warrning ~~~~. Hence removed the tag to format it similarly as other code snippets.

Hope it will be helpful. Thanks.