### PR TITLE
Remove XCTest from custom-set

### DIFF
--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -9,7 +9,8 @@
     "lyuha",
     "robtimp",
     "samkrishna",
-    "ThomasHaz"
+    "ThomasHaz",
+    "Sencudra"
   ],
   "files": {
     "solution": [

--- a/exercises/practice/custom-set/.meta/template.swift
+++ b/exercises/practice/custom-set/.meta/template.swift
@@ -1,81 +1,73 @@
-import XCTest
-@testable import {{exercise|camelCase}}
-class {{exercise|camelCase}}Tests: XCTestCase {
-    let runAll = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"]) ?? false
-    let emptyArray = [Int]()
+import Foundation
+import Testing
 
+@testable import {{ exercise|camelCase }}
+
+let RUNALL = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"]) ?? false
+
+@Suite
+struct {{ exercise|camelCase }}Tests {
+    
     {% outer: for case in cases %}
         {%- for subCases in case.cases %}
-        {%- if forloop.outer.first and forloop.first %}
-            func test{{subCases.description |camelCase }}() {
-        {%- else %}
-            func test{{subCases.description |camelCase }}() throws {
-            try XCTSkipIf(true && !runAll) // change true to false to run this test
-        {%- endif %}
-        {%- if subCases.input | length == 2 and not subCases.input.element %}
-            {%- if subCases.input.set1 %}
-            let set1 = {{exercise|camelCase}}({{subCases.input.set1}})
-            {%- else %}
-            let set1 = {{exercise|camelCase}}(emptyArray)
-            {%- endif %}
-            {%- if subCases.input.set2 %}
-            let set2 = {{exercise|camelCase}}({{subCases.input.set2}})
-            {%- else %}
-            let set2 = {{exercise|camelCase}}(emptyArray)
-            {%- endif %}
-        {%- else %}
-            {%- if subCases.input.set and (subCases.property == "empty" or subCases.property == "contains") %}
-            let customSet = {{exercise|camelCase}}({{subCases.input.set}})
-            {%- elif subCases.input.set %}
-            var customSet = {{exercise|camelCase}}({{subCases.input.set}})
-            {%- elif subCases.property == "empty" or subCases.property == "contains" %}
-            let customSet = {{exercise|camelCase}}(emptyArray)
-            {%- else %}
-            var customSet = {{exercise|camelCase}}(emptyArray)
-            {%- endif %}
-        {%- endif %}
+            {%- if forloop.outer.first and forloop.first %}
+                @Test("{{ subCases.description }}")
+            {% else -%}
+                @Test("{{ subCases.description }}", .enabled(if: RUNALL))
+            {% endif -%}
+            func test{{ subCases.description|camelCase }}() {
+                {%- if subCases.input|contains:"set" %}
+                    {%- if (subCases.property == "empty" or subCases.property == "contains") %}
+                    let
+                    {%- else %}
+                    var
+                    {%- endif %}
+                    customSet = {{ exercise|camelCase }}(
+                        {%- if subCases.input.set -%}
+                            {{ subCases.input.set }}
+                        {%- else -%}
+                            [Int]()
+                        {%- endif -%}
+                    )
+                {%- elif subCases.input|contains:"set1" and subCases.input|contains:"set2" %}
+                    let set1 = {{ exercise|camelCase }}(
+                        {%- if subCases.input.set1 -%} 
+                            {{ subCases.input.set1 }}
+                        {%- else -%}
+                            [Int]()
+                        {%- endif -%}
+                    )
+                    let set2 = {{ exercise|camelCase }}(
+                        {%- if subCases.input.set2 -%} 
+                            {{ subCases.input.set2 }}
+                        {%- else -%}
+                            [Int]()
+                        {%- endif -%}
+                    )
+                {%- endif %}
 
-        {%- if subCases.property == "empty" %}
-            {%- if subCases.expected %}
-            XCTAssertTrue(customSet.isEmpty)
-            {%- else %}
-            XCTAssertFalse(customSet.isEmpty)
-            {%- endif %}
-        {%- elif subCases.property == "contains"%}
-            {%- if subCases.expected %}
-            XCTAssertTrue(customSet.contains({{subCases.input.element}}))
-            {%- else %}
-            XCTAssertFalse(customSet.contains({{subCases.input.element}}))
-            {%- endif %}
-        {%- elif subCases.property == "subset" %}
-            {%- if subCases.expected %}
-            XCTAssertTrue(set1.isSubset(of: set2))
-            {%- else %}
-            XCTAssertFalse(set1.isSubset(of: set2))
-            {%- endif %}
-        {%- elif subCases.property == "disjoint" %}
-            {%- if subCases.expected %}
-            XCTAssertTrue(set1.isDisjoint(with: set2))
-            {%- else %}
-            XCTAssertFalse(set1.isDisjoint(with:set2))
-            {%- endif %}
-        {%- elif subCases.property == "equal" %}
-            {%- if subCases.expected %}
-            XCTAssertEqual(set1, set2)
-            {%- else %}
-            XCTAssertNotEqual(set1, set2)
-            {%- endif %}
-        {%- elif subCases.property == "add"%}
-            customSet.add({{subCases.input.element}})
-            XCTAssertEqual(customSet, {{exercise|camelCase}}({{subCases.expected}}))
-        {%- elif subCases.property == "intersection" %}
-            XCTAssertEqual(set1.intersection(set2), {{exercise|camelCase}}({{subCases.expected}}))
-        {%- elif subCases.property == "union" %}
-            XCTAssertEqual(set1.union(set2), {{exercise|camelCase}}({{subCases.expected}}))
-        {%- elif subCases.property == "difference" %}
-            XCTAssertEqual(set1.difference(set2), {{exercise|camelCase}}({{subCases.expected}}))
-        {%- endif %}
-        }
+                {%- if subCases.property == "empty" %}
+                    #expect(customSet.isEmpty == {{ subCases.expected|toBoolean }})
+                {%- elif subCases.property == "contains" %}
+                    #expect(customSet.contains({{ subCases.input.element }}) == {{ subCases.expected|toBoolean }})
+                {%- elif subCases.property == "subset" %}
+                    #expect(set1.isSubset(of: set2) == {{ subCases.expected|toBoolean }})
+                {%- elif subCases.property == "disjoint" %}
+                    #expect(set1.isDisjoint(with: set2) == {{ subCases.expected|toBoolean }})
+                {%- elif subCases.property == "equal" %}
+                    #expect((set1 == set2) == {{ subCases.expected|toBoolean }})
+                {%- elif subCases.property == "add"%}
+                    customSet.add({{subCases.input.element}})
+                    #expect(customSet == {{ exercise|camelCase }}({{ subCases.expected }}))
+                {%- elif subCases.property == "intersection" %}
+                    #expect(set1.intersection(set2) == {{ exercise|camelCase }}({{ subCases.expected }}))
+                {%- elif subCases.property == "union" %}
+                    #expect(set1.union(set2) == {{ exercise|camelCase }}({{ subCases.expected }}))
+                {%- elif subCases.property == "difference" %}
+                    #expect(set1.difference(set2) == {{ exercise|camelCase }}({{ subCases.expected }}))
+                {%- endif %}
+            }
         {% endfor -%}
     {% endfor -%}
+
 }

--- a/exercises/practice/custom-set/Package.swift
+++ b/exercises/practice/custom-set/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:6.0
 
 import PackageDescription
 

--- a/exercises/practice/custom-set/Sources/CustomSet/CustomSet.swift
+++ b/exercises/practice/custom-set/Sources/CustomSet/CustomSet.swift
@@ -1,1 +1,2 @@
+
 // Write your code for the 'Custom-Set' exercise in this file.

--- a/exercises/practice/custom-set/Tests/CustomSetTests/CustomSetTests.swift
+++ b/exercises/practice/custom-set/Tests/CustomSetTests/CustomSetTests.swift
@@ -1,268 +1,238 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import CustomSet
 
-class CustomSetTests: XCTestCase {
-  let runAll = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"]) ?? false
-  let emptyArray = [Int]()
+let RUNALL = Bool(ProcessInfo.processInfo.environment["RUNALL", default: "false"]) ?? false
 
+@Suite
+struct CustomSetTests {
+
+  @Test("sets with no elements are empty")
   func testSetsWithNoElementsAreEmpty() {
-    let customSet = CustomSet(emptyArray)
-    XCTAssertTrue(customSet.isEmpty)
+    let customSet = CustomSet([Int]())
+    #expect(customSet.isEmpty == true)
   }
-
-  func testSetsWithElementsAreNotEmpty() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("sets with elements are not empty", .enabled(if: RUNALL))
+  func testSetsWithElementsAreNotEmpty() {
     let customSet = CustomSet([1])
-    XCTAssertFalse(customSet.isEmpty)
+    #expect(customSet.isEmpty == false)
   }
-
-  func testNothingIsContainedInAnEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let customSet = CustomSet(emptyArray)
-    XCTAssertFalse(customSet.contains(1))
+  @Test("nothing is contained in an empty set", .enabled(if: RUNALL))
+  func testNothingIsContainedInAnEmptySet() {
+    let customSet = CustomSet([Int]())
+    #expect(customSet.contains(1) == false)
   }
-
-  func testWhenTheElementIsInTheSet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("when the element is in the set", .enabled(if: RUNALL))
+  func testWhenTheElementIsInTheSet() {
     let customSet = CustomSet([1, 2, 3])
-    XCTAssertTrue(customSet.contains(1))
+    #expect(customSet.contains(1) == true)
   }
-
-  func testWhenTheElementIsNotInTheSet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("when the element is not in the set", .enabled(if: RUNALL))
+  func testWhenTheElementIsNotInTheSet() {
     let customSet = CustomSet([1, 2, 3])
-    XCTAssertFalse(customSet.contains(4))
+    #expect(customSet.contains(4) == false)
   }
-
-  func testEmptySetIsASubsetOfAnotherEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let set1 = CustomSet(emptyArray)
-    let set2 = CustomSet(emptyArray)
-    XCTAssertTrue(set1.isSubset(of: set2))
+  @Test("empty set is a subset of another empty set", .enabled(if: RUNALL))
+  func testEmptySetIsASubsetOfAnotherEmptySet() {
+    let set1 = CustomSet([Int]())
+    let set2 = CustomSet([Int]())
+    #expect(set1.isSubset(of: set2) == true)
   }
-
-  func testEmptySetIsASubsetOfNonEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let set1 = CustomSet(emptyArray)
+  @Test("empty set is a subset of non-empty set", .enabled(if: RUNALL))
+  func testEmptySetIsASubsetOfNonEmptySet() {
+    let set1 = CustomSet([Int]())
     let set2 = CustomSet([1])
-    XCTAssertTrue(set1.isSubset(of: set2))
+    #expect(set1.isSubset(of: set2) == true)
   }
-
-  func testNonEmptySetIsNotASubsetOfEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("non-empty set is not a subset of empty set", .enabled(if: RUNALL))
+  func testNonEmptySetIsNotASubsetOfEmptySet() {
     let set1 = CustomSet([1])
-    let set2 = CustomSet(emptyArray)
-    XCTAssertFalse(set1.isSubset(of: set2))
+    let set2 = CustomSet([Int]())
+    #expect(set1.isSubset(of: set2) == false)
   }
-
-  func testSetIsASubsetOfSetWithExactSameElements() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("set is a subset of set with exact same elements", .enabled(if: RUNALL))
+  func testSetIsASubsetOfSetWithExactSameElements() {
     let set1 = CustomSet([1, 2, 3])
     let set2 = CustomSet([1, 2, 3])
-    XCTAssertTrue(set1.isSubset(of: set2))
+    #expect(set1.isSubset(of: set2) == true)
   }
-
-  func testSetIsASubsetOfLargerSetWithSameElements() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("set is a subset of larger set with same elements", .enabled(if: RUNALL))
+  func testSetIsASubsetOfLargerSetWithSameElements() {
     let set1 = CustomSet([1, 2, 3])
     let set2 = CustomSet([4, 1, 2, 3])
-    XCTAssertTrue(set1.isSubset(of: set2))
+    #expect(set1.isSubset(of: set2) == true)
   }
-
-  func testSetIsNotASubsetOfSetThatDoesNotContainItsElements() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("set is not a subset of set that does not contain its elements", .enabled(if: RUNALL))
+  func testSetIsNotASubsetOfSetThatDoesNotContainItsElements() {
     let set1 = CustomSet([1, 2, 3])
     let set2 = CustomSet([4, 1, 3])
-    XCTAssertFalse(set1.isSubset(of: set2))
+    #expect(set1.isSubset(of: set2) == false)
   }
-
-  func testTheEmptySetIsDisjointWithItself() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let set1 = CustomSet(emptyArray)
-    let set2 = CustomSet(emptyArray)
-    XCTAssertTrue(set1.isDisjoint(with: set2))
+  @Test("the empty set is disjoint with itself", .enabled(if: RUNALL))
+  func testTheEmptySetIsDisjointWithItself() {
+    let set1 = CustomSet([Int]())
+    let set2 = CustomSet([Int]())
+    #expect(set1.isDisjoint(with: set2) == true)
   }
-
-  func testEmptySetIsDisjointWithNonEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let set1 = CustomSet(emptyArray)
+  @Test("empty set is disjoint with non-empty set", .enabled(if: RUNALL))
+  func testEmptySetIsDisjointWithNonEmptySet() {
+    let set1 = CustomSet([Int]())
     let set2 = CustomSet([1])
-    XCTAssertTrue(set1.isDisjoint(with: set2))
+    #expect(set1.isDisjoint(with: set2) == true)
   }
-
-  func testNonEmptySetIsDisjointWithEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("non-empty set is disjoint with empty set", .enabled(if: RUNALL))
+  func testNonEmptySetIsDisjointWithEmptySet() {
     let set1 = CustomSet([1])
-    let set2 = CustomSet(emptyArray)
-    XCTAssertTrue(set1.isDisjoint(with: set2))
+    let set2 = CustomSet([Int]())
+    #expect(set1.isDisjoint(with: set2) == true)
   }
-
-  func testSetsAreNotDisjointIfTheyShareAnElement() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("sets are not disjoint if they share an element", .enabled(if: RUNALL))
+  func testSetsAreNotDisjointIfTheyShareAnElement() {
     let set1 = CustomSet([1, 2])
     let set2 = CustomSet([2, 3])
-    XCTAssertFalse(set1.isDisjoint(with: set2))
+    #expect(set1.isDisjoint(with: set2) == false)
   }
-
-  func testSetsAreDisjointIfTheyShareNoElements() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("sets are disjoint if they share no elements", .enabled(if: RUNALL))
+  func testSetsAreDisjointIfTheyShareNoElements() {
     let set1 = CustomSet([1, 2])
     let set2 = CustomSet([3, 4])
-    XCTAssertTrue(set1.isDisjoint(with: set2))
+    #expect(set1.isDisjoint(with: set2) == true)
   }
-
-  func testEmptySetsAreEqual() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let set1 = CustomSet(emptyArray)
-    let set2 = CustomSet(emptyArray)
-    XCTAssertEqual(set1, set2)
+  @Test("empty sets are equal", .enabled(if: RUNALL))
+  func testEmptySetsAreEqual() {
+    let set1 = CustomSet([Int]())
+    let set2 = CustomSet([Int]())
+    #expect((set1 == set2) == true)
   }
-
-  func testEmptySetIsNotEqualToNonEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let set1 = CustomSet(emptyArray)
+  @Test("empty set is not equal to non-empty set", .enabled(if: RUNALL))
+  func testEmptySetIsNotEqualToNonEmptySet() {
+    let set1 = CustomSet([Int]())
     let set2 = CustomSet([1, 2, 3])
-    XCTAssertNotEqual(set1, set2)
+    #expect((set1 == set2) == false)
   }
-
-  func testNonEmptySetIsNotEqualToEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("non-empty set is not equal to empty set", .enabled(if: RUNALL))
+  func testNonEmptySetIsNotEqualToEmptySet() {
     let set1 = CustomSet([1, 2, 3])
-    let set2 = CustomSet(emptyArray)
-    XCTAssertNotEqual(set1, set2)
+    let set2 = CustomSet([Int]())
+    #expect((set1 == set2) == false)
   }
-
-  func testSetsWithTheSameElementsAreEqual() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("sets with the same elements are equal", .enabled(if: RUNALL))
+  func testSetsWithTheSameElementsAreEqual() {
     let set1 = CustomSet([1, 2])
     let set2 = CustomSet([2, 1])
-    XCTAssertEqual(set1, set2)
+    #expect((set1 == set2) == true)
   }
-
-  func testSetsWithDifferentElementsAreNotEqual() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("sets with different elements are not equal", .enabled(if: RUNALL))
+  func testSetsWithDifferentElementsAreNotEqual() {
     let set1 = CustomSet([1, 2, 3])
     let set2 = CustomSet([1, 2, 4])
-    XCTAssertNotEqual(set1, set2)
+    #expect((set1 == set2) == false)
   }
-
-  func testSetIsNotEqualToLargerSetWithSameElements() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("set is not equal to larger set with same elements", .enabled(if: RUNALL))
+  func testSetIsNotEqualToLargerSetWithSameElements() {
     let set1 = CustomSet([1, 2, 3])
     let set2 = CustomSet([1, 2, 3, 4])
-    XCTAssertNotEqual(set1, set2)
+    #expect((set1 == set2) == false)
   }
-
-  func testAddToEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    var customSet = CustomSet(emptyArray)
+  @Test("add to empty set", .enabled(if: RUNALL))
+  func testAddToEmptySet() {
+    var customSet = CustomSet([Int]())
     customSet.add(3)
-    XCTAssertEqual(customSet, CustomSet([3]))
+    #expect(customSet == CustomSet([3]))
   }
-
-  func testAddToNonEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("add to non-empty set", .enabled(if: RUNALL))
+  func testAddToNonEmptySet() {
     var customSet = CustomSet([1, 2, 4])
     customSet.add(3)
-    XCTAssertEqual(customSet, CustomSet([1, 2, 3, 4]))
+    #expect(customSet == CustomSet([1, 2, 3, 4]))
   }
-
-  func testAddingAnExistingElementDoesNotChangeTheSet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("adding an existing element does not change the set", .enabled(if: RUNALL))
+  func testAddingAnExistingElementDoesNotChangeTheSet() {
     var customSet = CustomSet([1, 2, 3])
     customSet.add(3)
-    XCTAssertEqual(customSet, CustomSet([1, 2, 3]))
+    #expect(customSet == CustomSet([1, 2, 3]))
   }
-
-  func testIntersectionOfTwoEmptySetsIsAnEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let set1 = CustomSet(emptyArray)
-    let set2 = CustomSet(emptyArray)
-    XCTAssertEqual(set1.intersection(set2), CustomSet([]))
+  @Test("intersection of two empty sets is an empty set", .enabled(if: RUNALL))
+  func testIntersectionOfTwoEmptySetsIsAnEmptySet() {
+    let set1 = CustomSet([Int]())
+    let set2 = CustomSet([Int]())
+    #expect(set1.intersection(set2) == CustomSet([]))
   }
-
-  func testIntersectionOfAnEmptySetAndNonEmptySetIsAnEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let set1 = CustomSet(emptyArray)
+  @Test("intersection of an empty set and non-empty set is an empty set", .enabled(if: RUNALL))
+  func testIntersectionOfAnEmptySetAndNonEmptySetIsAnEmptySet() {
+    let set1 = CustomSet([Int]())
     let set2 = CustomSet([3, 2, 5])
-    XCTAssertEqual(set1.intersection(set2), CustomSet([]))
+    #expect(set1.intersection(set2) == CustomSet([]))
   }
-
-  func testIntersectionOfANonEmptySetAndAnEmptySetIsAnEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("intersection of a non-empty set and an empty set is an empty set", .enabled(if: RUNALL))
+  func testIntersectionOfANonEmptySetAndAnEmptySetIsAnEmptySet() {
     let set1 = CustomSet([1, 2, 3, 4])
-    let set2 = CustomSet(emptyArray)
-    XCTAssertEqual(set1.intersection(set2), CustomSet([]))
+    let set2 = CustomSet([Int]())
+    #expect(set1.intersection(set2) == CustomSet([]))
   }
-
-  func testIntersectionOfTwoSetsWithNoSharedElementsIsAnEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("intersection of two sets with no shared elements is an empty set", .enabled(if: RUNALL))
+  func testIntersectionOfTwoSetsWithNoSharedElementsIsAnEmptySet() {
     let set1 = CustomSet([1, 2, 3])
     let set2 = CustomSet([4, 5, 6])
-    XCTAssertEqual(set1.intersection(set2), CustomSet([]))
+    #expect(set1.intersection(set2) == CustomSet([]))
   }
-
-  func testIntersectionOfTwoSetsWithSharedElementsIsASetOfTheSharedElements() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test(
+    "intersection of two sets with shared elements is a set of the shared elements",
+    .enabled(if: RUNALL))
+  func testIntersectionOfTwoSetsWithSharedElementsIsASetOfTheSharedElements() {
     let set1 = CustomSet([1, 2, 3, 4])
     let set2 = CustomSet([3, 2, 5])
-    XCTAssertEqual(set1.intersection(set2), CustomSet([2, 3]))
+    #expect(set1.intersection(set2) == CustomSet([2, 3]))
   }
-
-  func testDifferenceOfTwoEmptySetsIsAnEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let set1 = CustomSet(emptyArray)
-    let set2 = CustomSet(emptyArray)
-    XCTAssertEqual(set1.difference(set2), CustomSet([]))
+  @Test("difference of two empty sets is an empty set", .enabled(if: RUNALL))
+  func testDifferenceOfTwoEmptySetsIsAnEmptySet() {
+    let set1 = CustomSet([Int]())
+    let set2 = CustomSet([Int]())
+    #expect(set1.difference(set2) == CustomSet([]))
   }
-
-  func testDifferenceOfEmptySetAndNonEmptySetIsAnEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let set1 = CustomSet(emptyArray)
+  @Test("difference of empty set and non-empty set is an empty set", .enabled(if: RUNALL))
+  func testDifferenceOfEmptySetAndNonEmptySetIsAnEmptySet() {
+    let set1 = CustomSet([Int]())
     let set2 = CustomSet([3, 2, 5])
-    XCTAssertEqual(set1.difference(set2), CustomSet([]))
+    #expect(set1.difference(set2) == CustomSet([]))
   }
-
-  func testDifferenceOfANonEmptySetAndAnEmptySetIsTheNonEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("difference of a non-empty set and an empty set is the non-empty set", .enabled(if: RUNALL))
+  func testDifferenceOfANonEmptySetAndAnEmptySetIsTheNonEmptySet() {
     let set1 = CustomSet([1, 2, 3, 4])
-    let set2 = CustomSet(emptyArray)
-    XCTAssertEqual(set1.difference(set2), CustomSet([1, 2, 3, 4]))
+    let set2 = CustomSet([Int]())
+    #expect(set1.difference(set2) == CustomSet([1, 2, 3, 4]))
   }
-
-  func testDifferenceOfTwoNonEmptySetsIsASetOfElementsThatAreOnlyInTheFirstSet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test(
+    "difference of two non-empty sets is a set of elements that are only in the first set",
+    .enabled(if: RUNALL))
+  func testDifferenceOfTwoNonEmptySetsIsASetOfElementsThatAreOnlyInTheFirstSet() {
     let set1 = CustomSet([3, 2, 1])
     let set2 = CustomSet([2, 4])
-    XCTAssertEqual(set1.difference(set2), CustomSet([1, 3]))
+    #expect(set1.difference(set2) == CustomSet([1, 3]))
   }
-
-  func testUnionOfEmptySetsIsAnEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let set1 = CustomSet(emptyArray)
-    let set2 = CustomSet(emptyArray)
-    XCTAssertEqual(set1.union(set2), CustomSet([]))
+  @Test("union of empty sets is an empty set", .enabled(if: RUNALL))
+  func testUnionOfEmptySetsIsAnEmptySet() {
+    let set1 = CustomSet([Int]())
+    let set2 = CustomSet([Int]())
+    #expect(set1.union(set2) == CustomSet([]))
   }
-
-  func testUnionOfAnEmptySetAndNonEmptySetIsTheNonEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
-    let set1 = CustomSet(emptyArray)
+  @Test("union of an empty set and non-empty set is the non-empty set", .enabled(if: RUNALL))
+  func testUnionOfAnEmptySetAndNonEmptySetIsTheNonEmptySet() {
+    let set1 = CustomSet([Int]())
     let set2 = CustomSet([2])
-    XCTAssertEqual(set1.union(set2), CustomSet([2]))
+    #expect(set1.union(set2) == CustomSet([2]))
   }
-
-  func testUnionOfANonEmptySetAndEmptySetIsTheNonEmptySet() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("union of a non-empty set and empty set is the non-empty set", .enabled(if: RUNALL))
+  func testUnionOfANonEmptySetAndEmptySetIsTheNonEmptySet() {
     let set1 = CustomSet([1, 3])
-    let set2 = CustomSet(emptyArray)
-    XCTAssertEqual(set1.union(set2), CustomSet([1, 3]))
+    let set2 = CustomSet([Int]())
+    #expect(set1.union(set2) == CustomSet([1, 3]))
   }
-
-  func testUnionOfNonEmptySetsContainsAllUniqueElements() throws {
-    try XCTSkipIf(true && !runAll)  // change true to false to run this test
+  @Test("union of non-empty sets contains all unique elements", .enabled(if: RUNALL))
+  func testUnionOfNonEmptySetsContainsAllUniqueElements() {
     let set1 = CustomSet([1, 3])
     let set2 = CustomSet([2, 3])
-    XCTAssertEqual(set1.union(set2), CustomSet([3, 2, 1]))
+    #expect(set1.union(set2) == CustomSet([3, 2, 1]))
   }
 }

--- a/generator/Sources/Generator/generator-plugins.swift
+++ b/generator/Sources/Generator/generator-plugins.swift
@@ -5,6 +5,13 @@ class GeneratorPlugins {
   func getPlugins() -> Environment {
     let ext = Extension()
 
+    ext.registerFilter("toBoolean") { (value: Any?) in
+      guard let intValue = value as? Int else {
+        return nil
+      }
+      return intValue != 0
+    }
+
     ext.registerFilter("isNull") { (value: Any?) in
       return NSNull().isEqual(value)
     }
@@ -36,6 +43,10 @@ class GeneratorPlugins {
       } else if let inputArray = value as? [Int] {
         if let number = args.first as? Int {
           return inputArray.contains(number)
+        }
+      } else if let inputDict = value as? [String: Any] {
+        if let string = args.first as? String {
+          return inputDict.keys.contains(string)
         }
       }
       return false

--- a/generator/readme.md
+++ b/generator/readme.md
@@ -51,9 +51,27 @@ include = false
 The generator also supports plugins, which can be used to add extra functionality to Stencils templates.
 The plugins are needed since Stencil doesn't support all the features we need.
 
-The current plugins are:
+The current custom plugins are:
+- `toBoolean`: Converts integer value to Boolean.
 - `isNull`: Checks if a value is null.
 - `camelCase`: Converts a string to camel case.
+- `contains`: Check if value is present in a String, array or dictionary.
+- `any`: Checks each element of an integer array for a specific condition: isEven, isOdd, isNegative, isPositive. The condition is passed as an argument.
+- `toStringArray`: Converts input value to array of strings.
+- `toStringDictionary`: Converts input value to dictionary structure.
+- `inspect`: Removes escape characters from string.
+- `minus`: Calculates difference between value and argument.
+- `toTupleArray`: Converts input value to [[Int]] or [[String]].
+- `extractCountKey`: Extracts value under "count" key value from dictionary.
+- `toNilArray`: Converts input value to an array with optional values.
+- `length`: Provides the length of a collection.
+- `toEnumArray`: Converts input value to a enum array.
+- `strain`: Performs problem-specific replacements in string.
+- `round`: Rounds the value with a specified precision.
+- `knapsackItem`: Snapsack specific plugin to generate Items.
+- `complexNumber`: Converts input value to swift syntax.
+- `listOps`: Replaces occurances of "foldr" to "foldRight"
+- `defaultArray`: Provides default value if the input value is null. 
 
 The plugins can be found in the `generator-plugins.swift` file, and can be used like this:
 


### PR DESCRIPTION
Modern test runner does not support parsing old XCTest tests. So, for now in this problem all submission attempts will fail. Custom set is the last non-deprecated problem where XCTests is present. This PR converts the template and tests to Swift Testing.

What's more: add some required plugins to the generator and list all the plugins in readme. Some of them look weird, but it's another story.