### PR TITLE
Remove Swift 6.0 from CI matrix, keeping only Swift 6.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-15]
-        swift: ["6.0", "6.1"]
+        swift: ["6.1"]
     env:
       RUNALL: "true"
     steps:


### PR DESCRIPTION
Swift 6 ci is now also broken (Ubuntu was broken and removed). I would suppose that this is caused by the underlying macos image changed which caused it to fail. For now the easiest fix is just removing the ci.