### PR TITLE
wrong layout in __inout parameter__ concept introduction: still not fixed

### DIFF
--- a/concepts/inout-parameters/about.md
+++ b/concepts/inout-parameters/about.md
@@ -22,7 +22,7 @@ updateVersion(&dbRecord)
 // dbRecord is now (3, "Exercism")
 ```
 
-~~~~exercism/warning
+~~~~exercism/caution
 There are a couple of extra rules one should be aware of regarding in-out parameters.
 
 1.  Inside a function with in-out parameters, you are not allowed to reference the variable that was passed in as the in-out parameter.

--- a/concepts/inout-parameters/about.md
+++ b/concepts/inout-parameters/about.md
@@ -25,8 +25,23 @@ updateVersion(&dbRecord)
 ~~~~exercism/caution
 There are a couple of extra rules one should be aware of regarding in-out parameters.
 
-1.  Inside a function with in-out parameters, you are not allowed to reference the variable that was passed in as the in-out parameter.
+1.  Inside a function with in-out parameters, you are not allowed to directly reference the variable that was also passed in as the in-out parameter.
 2.  The same variable cannot be passed as multiple in-out parameters in the same function.
+
+```swift
+var directVar = 0
+
+func inoutFunc(_ ioVar: inout Int) {
+  ioVar += 1
+  print(directVar)
+}
+
+inoutFunc(&directVar)
+// raises a compiler error:
+// "main actor-isolated var 'directVar' can not be referenced from a nonisolated context"
+```
+
+[TODO]: # (error message is not beginner-friendly)
 
 ```swift
 func inoutFunc(_ ioVar1: inout Int, _ ioVar2: inout Int) {

--- a/concepts/inout-parameters/introduction.md
+++ b/concepts/inout-parameters/introduction.md
@@ -22,7 +22,7 @@ updateVersion(&dbRecord)
 // dbRecord is now (3, "Exercism")
 ```
 
-~~~~exercism/warning
+~~~~exercism/caution
 There are a couple of extra rules one should be aware of regarding in-out parameters.
 
 1.  Inside a function with in-out parameters, you are not allowed to reference the variable that was passed in as the in-out parameter.

--- a/concepts/inout-parameters/introduction.md
+++ b/concepts/inout-parameters/introduction.md
@@ -25,8 +25,23 @@ updateVersion(&dbRecord)
 ~~~~exercism/caution
 There are a couple of extra rules one should be aware of regarding in-out parameters.
 
-1.  Inside a function with in-out parameters, you are not allowed to reference the variable that was passed in as the in-out parameter.
+1.  Inside a function with in-out parameters, you are not allowed to directly reference the variable that was also passed in as the in-out parameter.
 2.  The same variable cannot be passed as multiple in-out parameters in the same function.
+
+```swift
+var directVar = 0
+
+func inoutFunc(_ ioVar: inout Int) {
+  ioVar += 1
+  print(directVar)
+}
+
+inoutFunc(&directVar)
+// raises a compiler error:
+// "main actor-isolated var 'directVar' can not be referenced from a nonisolated context"
+```
+
+[TODO]: # (error message is not beginner-friendly)
 
 ```swift
 func inoutFunc(_ ioVar1: inout Int, _ ioVar2: inout Int) {
@@ -39,5 +54,6 @@ inoutFunc(&mutVar, &mutVar)
 // raises a compiler error: "Inout arguments are not allowed to alias each other"
 ```
 ~~~~
+
 
 [in-out-parameters]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/declarations/#In-Out-Parameters

--- a/exercises/concept/lasagna-master/.docs/hints.md
+++ b/exercises/concept/lasagna-master/.docs/hints.md
@@ -28,7 +28,7 @@
 - Nested functions have access to all of the parameter, constants, and variables of the surrounding function. There is no need to pass them in to the nested function.
 
 [functions]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/functions/
-[type annotations]: [type annotations]: https://docs.swift.org/swift-book/LanguageGuide/TheBasics.html#ID312
+[type annotations]: https://docs.swift.org/swift-book/LanguageGuide/TheBasics.html#ID312
 [argument labels]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/functions/#Function-Argument-Labels-and-Parameter-Names
 [multiple-return-values]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/functions/#Functions-with-Multiple-Return-Values
 [implicit-returns]: https://docs.swift.org/swift-book/documentation/the-swift-programming-language/functions#Functions-With-an-Implicit-Return

--- a/exercises/concept/lasagna-master/.docs/introduction.md
+++ b/exercises/concept/lasagna-master/.docs/introduction.md
@@ -68,8 +68,23 @@ updateVersion(&dbRecord)
 ~~~~exercism/caution
 There are a couple of extra rules one should be aware of regarding in-out parameters.
 
-1.  Inside a function with in-out parameters, you are not allowed to reference the variable that was passed in as the in-out parameter.
+1.  Inside a function with in-out parameters, you are not allowed to directly reference the variable that was also passed in as the in-out parameter.
 2.  The same variable cannot be passed as multiple in-out parameters in the same function.
+
+```swift
+var directVar = 0
+
+func inoutFunc(_ ioVar: inout Int) {
+  ioVar += 1
+  print(directVar)
+}
+
+inoutFunc(&directVar)
+// raises a compiler error:
+// "main actor-isolated var 'directVar' can not be referenced from a nonisolated context"
+```
+
+[TODO]: # (error message is not beginner-friendly)
 
 ```swift
 func inoutFunc(_ ioVar1: inout Int, _ ioVar2: inout Int) {

--- a/exercises/concept/lasagna-master/.docs/introduction.md
+++ b/exercises/concept/lasagna-master/.docs/introduction.md
@@ -65,7 +65,7 @@ updateVersion(&dbRecord)
 // dbRecord is now (3, "Exercism")
 ```
 
-~~~~exercism/warning
+~~~~exercism/caution
 There are a couple of extra rules one should be aware of regarding in-out parameters.
 
 1.  Inside a function with in-out parameters, you are not allowed to reference the variable that was passed in as the in-out parameter.


### PR DESCRIPTION
<img width="1186" height="784" alt="image" src="https://github.com/user-attachments/assets/5c9bf9db-da68-4bef-be04-0453c70de168" />

if you search `exercism/warning` on `github.com/exercism`, it gives just 8 mentions, while searching `exercism/note` and `exercism/caution` gives >100. so i think it just doesn't understand `warning`

yet point 1 isn't very clear that it's about ownership and such, even in context of point 2. it sounds like "you can accept an inout parameter, yet you can't use it" instead of "don't alias the variable and its inout version in the same function". we probably also need an example for it?